### PR TITLE
Develop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-buster
+FROM python:3.12
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -1,128 +1,73 @@
 # Data Collection Service
 
-The Data Collection Service is a Python application that collects market data from the Binance API and stores it in ClickHouse. The service runs in a Docker container, making it easy to set up and use.
+Collector that ingests candles from configurable cryptofeed exchanges and stores them in ClickHouse. The stack ships with:
 
-## Features:
-- receiving real-time data on all coins from Binance-Futures (candles tf:"1m")
-- automatic validation and filling missed candles in data
-- automatic loading of history
-- automatic removal of duplicates
+- realtime streamer (`data_collector.py`) with shard rebalancing and ClickHouse retry logic;
+- historical backfill (`load_history.py`) that loads in configurable chunks only until the first existing candle;
+- quality watchdog (`data_quality_check.py`) that monitors freshness and refills gaps.
 
+## Features
+- supports spot/futures Binance feeds and any exchange exposed via cryptofeed (set in `config.yaml`);
+- Telegram notifications on startup, failures and stale data;
+- automatic gap detection and refill with configurable timeframe;
+- optional Docker Compose bundle for quick local spin-up.
 
 ## Requirements
-- Python 3.8 or higher
-- Cryptofeed
-- ClickHouse
-- Docker (if running in a Docker container)
+If you run locally:
 
-# Installation
-
-
-# Getting Started
+- Python 3.11+ (tested with 3.12)
+- ClickHouse 23+
+- Docker & Docker Compose (optional but recommended)
 
 ## Configuration
-Before using the Data Collection Service, you'll need to set up a configuration file named config.yaml. This file should be placed in the [./app](./app) directory of the project. You can use the provided [config_sample.yaml](./app/config_sample.yaml) as a starting point.
 
-### Using Docker
-To start the application services, navigate to the root directory of the project in your terminal and run the following command:
+Copy `app/config_sample.yaml` to `app/config.yaml` and adjust:
+
+- `EXCHANGE` / `COLLECTOR_EXCHANGE` / `HISTORY_EXCHANGE` — cryptofeed exchange code (`binance`, `binance_futures`, …);
+- `TIMEFRAME`, symbol filters and black/whitelists;
+- `HISTORY_CHUNK_SIZE` — max candles per request (clamped to 1500);
+- ClickHouse host/port overrides and Telegram credentials.
+
+For quality checker you can also override `DATA_QUALITY_EXCHANGE` if нужно другое подключение.
+
+## Running with Docker Compose
+
+```bash
+docker compose up --build
 ```
-docker-compose up
+
+
+Ensure ClickHouse is reachable at the host/port defined in `config.yaml`.
+
+## Exploring Data in a Notebook
+
+For ad-hoc analysis you can spin up JupyterLab alongside the services:
+
+```bash
+pip install jupyterlab clickhouse-driver
+jupyter lab --notebook-dir=notebooks
 ```
-This will start the data collector and data quality check services, as well as the ClickHouse database service. You should see the logs of the services in the terminal.
 
-### Accessing the Application
-Once the services are up and running, you can access the application at http://localhost:8123. This will open the ClickHouse web interface, where you can query the data that was collected and perform other database-related tasks.
+Example notebook snippet (`notebooks/ohlc_overview.ipynb`) to plot latest candles:
 
-### Stopping the Services
-To stop the application services, press Ctrl+C in the terminal where you started the services. This will stop and remove the containers, but the data in the data directory will persist.
-
-### Customizing the Configuration
-You can customize the services by modifying the docker-compose.yaml file. For example, you can change the image names or build contexts, adjust the container volumes, or set environment variables. Please refer to the [Docker Compose documentation](https://docs.docker.com/compose/) for more information on the available configuration options.
-
-___
-
-# Sample Code Use
-## Selecting Last 5000 Candles:
-python 
 ```python
-import clickhouse_driver
+import pandas as pd
+from clickhouse_driver import Client
 
-with clickhouse_driver.Client(host='localhost', port=9000) as ch:
-    # select last 5000 candles
-    query = f'SELECT * FROM binance_data.candles FINAL ORDER BY timestamp DESC LIMIT 5000'
-    result = ch.execute(query)
-
-print(result[:2])
-```
-output:
-```
-[('BINANCE_FUTURES',
-  'BTC-USDT-PERP',
-  datetime.datetime(2023, 2, 21, 20, 39),
-  datetime.datetime(2023, 2, 21, 20, 39, 59),
-  1677011968.0,
-  '1m',
-  1880,
-  24490.400390625,
-  24509.099609375,
-  24509.30078125,
-  24482.599609375,
-  214.322,
-  datetime.datetime(2023, 2, 21, 20, 40),
-  datetime.datetime(2023, 2, 21, 20, 40)),
- ('BINANCE_FUTURES',
-  'BTC-USDT-PERP',
-  datetime.datetime(2023, 2, 21, 20, 40),
-  datetime.datetime(2023, 2, 21, 20, 40, 59),
-  1677012096.0,
-  '1m',
-  2062,
-  24509.099609375,
-  24511.19921875,
-  24523.69921875,
-  24507.5,
-  183.713,
-  datetime.datetime(2023, 2, 21, 20, 41),
-  datetime.datetime(2023, 2, 21, 20, 41))]
+client = Client(host='localhost', port=9000)
+rows = client.execute(
+    """
+    SELECT symbol, start, open, high, low, close
+    FROM binance_data.candles FINAL
+    WHERE symbol IN ('BTC-USDT-PERP', 'ETH-USDT-PERP')
+      AND start >= subtractHours(now(), 6)
+    ORDER BY symbol, start
+    """
+)
+df = pd.DataFrame(rows, columns=['symbol', 'start', 'open', 'high', 'low', 'close'])
+df.set_index('start').groupby('symbol').plot()
 ```
 
-## Selecting All Candles of a Certain Coin:
-```python
-import clickhouse_driver
-
-with clickhouse_driver.Client(host='localhost', port=9000) as ch:
-    # select all candles of a certain coin
-    symbol = 'BTC-USDT-PERP'
-    query = '''SELECT * FROM binance_data.candles FINAL WHERE symbol = %(symbol)s'''
-    result = ch.execute(query, {'symbol': symbol,})
-```
+---
 
 
-# Project Structure
-
-The project has the following structure:
-
-```
-data-collection-service/
-├── app/
-│   ├── config_sample.yaml
-│   ├── data_collector.py
-│   ├── data_quality_check.py
-|   └── load_history.py
-├── docker-compose.yaml
-└── README.md
-```
-
-- The app directory contains the configuration file and the Python scripts for the data collector and data quality check services.
-- The docker-compose.yaml file defines the services and their dependencies.
-
-
-### data_collector.py
-The data_collector.py script collects candle data from Binance futures and stores it in ClickHouse.
-
-### data_quality_check.py
-The data_quality_check.py script checks the data quality of the candle data in ClickHouse. 
-
-### load_history.py
-This is a script that collects market data from the Binance exchange and stores it in a database called ClickHouse.
-The script is also configured using a file named "config.yaml", which contains settings such as the start date for collecting data and whether or not to load historical data. 

--- a/app/clickhouse_schema.py
+++ b/app/clickhouse_schema.py
@@ -1,0 +1,215 @@
+"""Utilities for managing ClickHouse schema used by the collectors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import clickhouse_driver
+
+DATABASE_NAME = 'binance_data'
+CANDLES_TABLE = 'candles'
+CANDLES_TABLE_FULL = f'{DATABASE_NAME}.{CANDLES_TABLE}'
+BASE_INTERVAL = '1m'
+ROLLUP_MINUTES = (5, 15, 30, 60, 120, 240, 1440)
+
+
+@dataclass(frozen=True)
+class RollupSpec:
+    """Definition for a materialized rollup timeframe."""
+
+    minutes: int
+    parent: 'RollupSpec | None' = None
+
+    @property
+    def label(self) -> str:
+        minutes = self.minutes
+        if minutes % 1440 == 0:
+            days = minutes // 1440
+            return f'{days}d'
+        if minutes % 60 == 0:
+            hours = minutes // 60
+            return f'{hours}h'
+        return f'{minutes}m'
+
+    @property
+    def source_label(self) -> str:
+        return BASE_INTERVAL if self.parent is None else self.parent.label
+
+    @property
+    def table_name(self) -> str:
+        return f'candles_{self.label}'
+
+    @property
+    def table_full(self) -> str:
+        return f'{DATABASE_NAME}.{self.table_name}'
+
+    @property
+    def view_name(self) -> str:
+        return f'mv_{self.source_label}_to_{self.label}'
+
+    @property
+    def view_full(self) -> str:
+        return f'{DATABASE_NAME}.{self.view_name}'
+
+    @property
+    def source_table_full(self) -> str:
+        return CANDLES_TABLE_FULL if self.parent is None else self.parent.table_full
+
+    @property
+    def source_time_column(self) -> str:
+        return 'start' if self.parent is None else 'candle_start'
+
+    @property
+    def uses_merge_states(self) -> bool:
+        return self.parent is not None
+
+    def interval_expr(self) -> str:
+        minutes = self.minutes
+        column = self.source_time_column
+        if minutes % 1440 == 0:
+            days = minutes // 1440
+            return f'toStartOfInterval({column}, INTERVAL {days} DAY)'
+        if minutes % 60 == 0:
+            hours = minutes // 60
+            return f'toStartOfInterval({column}, INTERVAL {hours} HOUR)'
+        return f'toStartOfInterval({column}, INTERVAL {minutes} MINUTE)'
+
+
+def build_rollup_specs() -> tuple[RollupSpec, ...]:
+    specs: list[RollupSpec] = []
+    parent: RollupSpec | None = None
+    for minutes in ROLLUP_MINUTES:
+        if parent and minutes % parent.minutes != 0:
+            raise ValueError(f'Невозможно построить каскад: {minutes} не кратно {parent.minutes}')
+        spec = RollupSpec(minutes=minutes, parent=parent)
+        specs.append(spec)
+        parent = spec
+    return tuple(specs)
+
+
+ROLLUP_SPECS = build_rollup_specs()
+
+CREATE_DATABASE_QUERY = f'CREATE DATABASE IF NOT EXISTS {DATABASE_NAME}'
+
+CREATE_CANDLES_TABLE_QUERY = f'''
+    CREATE TABLE IF NOT EXISTS {CANDLES_TABLE_FULL} (
+        exchange          LowCardinality(String),
+        symbol            LowCardinality(String),
+        interval          LowCardinality(String),
+        start             DateTime64(3, 'UTC') CODEC(DoubleDelta, ZSTD(1)),
+        stop              DateTime64(3, 'UTC') CODEC(DoubleDelta, ZSTD(1)),
+        close_unixtime    UInt64 CODEC(T64, ZSTD(1)),
+        trades            UInt32 CODEC(T64, ZSTD(1)),
+        open              Float64 CODEC(Gorilla, ZSTD),
+        high              Float64 CODEC(Gorilla, ZSTD),
+        low               Float64 CODEC(Gorilla, ZSTD),
+        close             Float64 CODEC(Gorilla, ZSTD),
+        volume            Float64 CODEC(DoubleDelta, ZSTD),
+        timestamp         DateTime64(3, 'UTC') CODEC(DoubleDelta, ZSTD(1)),
+        receipt_timestamp DateTime64(3, 'UTC') DEFAULT now64(3) CODEC(DoubleDelta, ZSTD(1)),
+        CONSTRAINT ohlc_finite CHECK isFinite(open) AND isFinite(high) AND isFinite(low) AND isFinite(close) AND isFinite(volume),
+        CONSTRAINT ohlc_order CHECK (low <= least(open, close) AND high >= greatest(open, close) AND low <= high),
+        CONSTRAINT close_time_positive CHECK close_unixtime > 0,
+        CONSTRAINT keys_not_empty CHECK (exchange != '' AND symbol != '' AND interval != '')
+    ) ENGINE = ReplacingMergeTree(receipt_timestamp)
+    PARTITION BY toYYYYMM(start)
+    ORDER BY (exchange, symbol, start, interval)
+    SETTINGS index_granularity = 8192
+'''
+
+def build_rollup_table_query(spec: RollupSpec) -> str:
+    return f'''
+        CREATE TABLE IF NOT EXISTS {spec.table_full} (
+            exchange       LowCardinality(String),
+            symbol         LowCardinality(String),
+            candle_start   DateTime64(3, 'UTC'),
+            open           AggregateFunction(argMin, Float64, DateTime64(3, 'UTC')),
+            high           AggregateFunction(max, Float64),
+            low            AggregateFunction(min, Float64),
+            close          AggregateFunction(argMax, Float64, DateTime64(3, 'UTC')),
+            volume         AggregateFunction(sum, Float64),
+            trades         AggregateFunction(sum, UInt64)
+        ) ENGINE = AggregatingMergeTree()
+        PARTITION BY toYYYYMM(candle_start)
+        ORDER BY (exchange, symbol, candle_start)
+    '''
+
+
+def build_rollup_view_query(spec: RollupSpec) -> str:
+    interval_expr = spec.interval_expr()
+    if spec.uses_merge_states:
+        open_expr = 'argMinMergeState(open)'
+        high_expr = 'maxMergeState(high)'
+        low_expr = 'minMergeState(low)'
+        close_expr = 'argMaxMergeState(close)'
+        volume_expr = 'sumMergeState(volume)'
+        trades_expr = 'sumMergeState(trades)'
+        where_clause = ''
+        final_clause = ''
+    else:
+        open_expr = f'argMinState(open, {spec.source_time_column})'
+        high_expr = 'maxState(high)'
+        low_expr = 'minState(low)'
+        close_expr = f'argMaxState(close, {spec.source_time_column})'
+        volume_expr = 'sumState(volume)'
+        trades_expr = 'sumState(toUInt64(trades))'
+        where_clause = f"WHERE interval = '{BASE_INTERVAL}'"
+        # FINAL запрещён в MATERIALIZED VIEW — убираем
+        final_clause = ''
+
+    return f'''
+        CREATE MATERIALIZED VIEW IF NOT EXISTS {spec.view_full}
+        TO {spec.table_full}
+        AS
+        SELECT
+            exchange,
+            symbol,
+            {interval_expr} AS candle_start,
+            {open_expr} AS open,
+            {high_expr} AS high,
+            {low_expr} AS low,
+            {close_expr} AS close,
+            {volume_expr} AS volume,
+            {trades_expr} AS trades
+        FROM {spec.source_table_full} {final_clause}
+        {where_clause}
+        GROUP BY exchange, symbol, candle_start
+    '''
+
+
+ROLLUP_TABLE_QUERIES = tuple(build_rollup_table_query(spec) for spec in ROLLUP_SPECS)
+ROLLUP_VIEW_QUERIES = tuple(build_rollup_view_query(spec) for spec in ROLLUP_SPECS)
+
+def drop_rollup_structures(client: clickhouse_driver.Client) -> None:
+    """
+    Drop rollup MATERIALIZED VIEWs and tables if they exist.
+    Important: drop views first (they depend on tables), then tables.
+    This is destructive and will remove aggregated data; base candles table is preserved.
+    """
+    # Drop all views (no specific order required)
+    for spec in ROLLUP_SPECS:
+        client.execute(f"DROP VIEW IF EXISTS {spec.view_full}")
+    # Drop all tables
+    for spec in ROLLUP_SPECS:
+        client.execute(f"DROP TABLE IF EXISTS {spec.table_full}")
+
+INSERT_CANDLES_QUERY = f'''
+    INSERT INTO {CANDLES_TABLE_FULL}
+    (exchange, symbol, interval, start, stop, close_unixtime, trades, open, high, low, close, volume, timestamp, receipt_timestamp)
+    VALUES
+    (%(exchange)s, %(symbol)s, %(interval)s, %(start)s, %(stop)s, %(close_unixtime)s, %(trades)s, %(open)s, %(high)s, %(low)s, %(close)s, %(volume)s, %(timestamp)s, %(receipt_timestamp)s)
+'''
+
+
+def ensure_schema(host: str, port: int) -> None:
+    """Ensure the ClickHouse database and tables exist."""
+    with clickhouse_driver.Client(host=host, port=port) as client:
+        client.execute(CREATE_DATABASE_QUERY)
+        client.execute(CREATE_CANDLES_TABLE_QUERY)
+        # Destructive refresh of rollup structures to align data types (approved by user)
+        drop_rollup_structures(client)
+        # Re-create rollup tables and views with correct DateTime64(3, 'UTC') aggregate state types
+        for query in ROLLUP_TABLE_QUERIES:
+            client.execute(query)
+        for query in ROLLUP_VIEW_QUERIES:
+            client.execute(query)

--- a/app/config_sample.yaml
+++ b/app/config_sample.yaml
@@ -4,6 +4,16 @@
 
 TIMEFRAME: '1m'
 SYMBOLS_TYPE: '-USDT-PERP'
+SYMBOLS_WHITELIST: [BTC, ADA, BCH, BNB, DOGE, ETH, SOL, XRP]
+SYMBOLS_BLACKLIST: []
+CLICKHOUSE_HOST: 'clickhouse'
+CLICKHOUSE_PORT: 9000
+EXCHANGE: binance_futures
+HISTORY_CHUNK_SIZE: 1000
+SHARD_SIZE: 100
+WATCHER_INTERVAL_SEC: 60
+STARTUP_DELAY_SEC: 10
+DATA_QUALITY_STARTUP_DELAY_SEC: 120
 
 ########################################################################################################################
 # TELEGRAM
@@ -17,4 +27,4 @@ CHAT_ID: <YOU_CHAT_ID>
 ########################################################################################################################
 
 LOAD_HISTORY: True
-START_DATE: '2023-01-01 00:00:00'
+START_DATE: '2021-01-01 00:00:00'

--- a/app/data_collector.py
+++ b/app/data_collector.py
@@ -1,18 +1,20 @@
 import asyncio
 import sys
-from loguru import logger
-from cryptofeed import FeedHandler
-from decimal import Decimal
-from cryptofeed.exchanges import Binance
-from cryptofeed.defines import CANDLES
-from datetime import datetime
 import time
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Awaitable, Callable, Iterator, List, Optional, Sequence, Set
 
-import aioch
-from aioch import Client as AIOClickHouseClient
-import clickhouse_driver
 import yaml
+from aioch import Client as AIOClickHouseClient
+from cryptofeed import FeedHandler
+from cryptofeed.defines import CANDLES
+from loguru import logger
 #from asynch import connect
+
+from clickhouse_schema import INSERT_CANDLES_QUERY, ensure_schema
+from exchange_factory import create_exchange, get_exchange_class
+from telegram_notifier import TelegramNotifier
 
 
 logger.remove()
@@ -25,62 +27,107 @@ logger.add(
 
 logger.add("./logs/data_collector.log", rotation="1 MB", level="DEBUG", compression="zip")
 
+DEFAULT_CLICKHOUSE_HOST = 'clickhouse'
+DEFAULT_CLICKHOUSE_PORT = 9000
+CONFIG_PATH = "config.yaml"
+DEFAULT_SHARD_SIZE = 100
+DEFAULT_WATCHER_INTERVAL_SEC = 60
+DEFAULT_STARTUP_DELAY_SEC = 10
 
-def create_database_if_not_exists() -> None:
-    '''Creates the binance_data database if it doesn't exist.'''
-    with clickhouse_driver.Client(host='clickhouse', port=9000) as ch:
-        ch.execute('CREATE DATABASE IF NOT EXISTS binance_data')
-        logger.info('CREATE DATABASE IF NOT EXISTS binance_data')
-
-def create_table_if_not_exists() -> None:
-    '''Creates the binance_data.candles table if it doesn't exist.'''
-    query = '''
-        CREATE TABLE IF NOT EXISTS binance_data.candles (
-            exchange String,
-            symbol String,
-            start DateTime,
-            stop DateTime,
-            close_unixtime Float32,
-            interval String,
-            trades Int32,
-            open Float32,
-            close Float32,
-            high Float32,
-            low Float32,
-            volume Float64,
-            timestamp DateTime,
-            receipt_timestamp DateTime
-        ) ENGINE = ReplacingMergeTree(receipt_timestamp)
-        ORDER BY (symbol, interval, start)
-    '''
-    with clickhouse_driver.Client(host='clickhouse', port=9000) as ch:
-        ch.execute(query)
-        logger.info('CREATE TABLE IF NOT EXISTS binance_data.candles')
-
-# -------- Sharding helpers and symbols watcher (hot-add only; removal via shard-restart to be added) --------
-def chunks(lst, n):
-    """Yield successive n-sized chunks from lst."""
-    for i in range(0, len(lst), n):
-        yield lst[i:i + n]
-
-
-async def symbols_watcher(handler: FeedHandler, symbol_type: str, timeframe: str, known_symbols: set, interval_sec: int = 60):
-    """
-    Periodically polls available symbols and hot-adds newly listed ones as shard feeds to the existing FeedHandler.
-    De-listing is only logged here; safe removal will be done via partial shard restart (not implemented in this watcher).
+def chunks(lst: Sequence[str], chunk_size: int) -> Iterator[List[str]]:
+    """Yield successive chunks from ``lst`` with at most ``chunk_size`` items.
 
     Args:
-        handler: Active FeedHandler instance.
-        symbol_type: Filter substring for symbols (e.g. '-USDT-PERP').
-        timeframe: Candle interval (e.g. '1m').
-        known_symbols: Mutable set of currently subscribed symbols, will be updated in-place.
-        interval_sec: Poll interval in seconds.
+        lst (Sequence[str]): Source collection to split.
+        chunk_size (int): Upper bound for symbols per chunk.
+
+    Yields:
+        list[str]: Subsequent slices of the original list.
+
+    Raises:
+        ValueError: If ``chunk_size`` is zero or negative.
     """
-    callbacks = {CANDLES: candle_callback}
+    if chunk_size <= 0:
+        raise ValueError('chunk_size must be greater than zero')
+
+    for i in range(0, len(lst), chunk_size):
+        yield list(lst[i:i + chunk_size])
+
+def filter_symbols(
+    all_symbols: Sequence[str],
+    symbol_type: str,
+    whitelist: Optional[Sequence[str]] = None,
+    blacklist: Optional[Sequence[str]] = None,
+    *,
+    log_missing: bool = True,
+) -> List[str]:
+    """Filter symbols using optional whitelist/blacklist overlays.
+
+    Args:
+        all_symbols (Sequence[str]): Raw universe returned by the exchange.
+        symbol_type (str): Substring filter applied when whitelist is empty.
+        whitelist (Sequence[str] | None): Explicit symbols to keep (takes priority).
+        blacklist (Sequence[str] | None): Symbols to exclude from the result.
+        log_missing (bool): When True, emits warnings for whitelist entries not on the exchange.
+
+    Returns:
+        list[str]: Sorted collection of symbols that pass configured filters.
+    """
+    whitelist = list(whitelist or [])
+    blacklist = set(blacklist or [])
+
+    if whitelist:
+        available = set(all_symbols)
+        if log_missing:
+            missing = [symbol for symbol in whitelist if symbol not in available]
+            if missing:
+                logger.warning(f'Whitelist symbols not available on exchange: {missing}')
+        filtered = [symbol for symbol in whitelist if symbol in available]
+    else:
+        filtered = [symbol for symbol in all_symbols if symbol_type in symbol]
+
+    filtered = [symbol for symbol in filtered if symbol not in blacklist]
+
+    return sorted(filtered)
+
+
+async def symbols_watcher(
+    handler: FeedHandler,
+    exchange_name: str,
+    exchange_class: type,
+    symbol_type: str,
+    timeframe: str,
+    known_symbols: Set[str],
+    whitelist: Sequence[str],
+    blacklist: Sequence[str],
+    candle_handler: Callable[..., Awaitable[None]],
+    *,
+    shard_size: int,
+    interval_sec: int = DEFAULT_WATCHER_INTERVAL_SEC,
+) -> None:
+    """Monitor Binance listings and hot-add new symbols.
+
+    Args:
+        handler (FeedHandler): Active feed handler to augment with new shards.
+        exchange_name (str): Configured exchange identifier used for new feed instances.
+        exchange_class (type): Exchange class providing symbol discovery.
+        symbol_type (str): Substring filter used when whitelist is empty.
+        timeframe (str): Candle interval requested from Binance.
+        known_symbols (set[str]): Mutable set of symbols already subscribed.
+        whitelist (Sequence[str]): Explicit list of allowed symbols (may be empty).
+        blacklist (Sequence[str]): Symbols to skip even if they pass other filters.
+        candle_handler: Callback used to store executed candles.
+        shard_size (int): Chunk size applied when hot-adding new feeds.
+        interval_sec (int): Poll interval to refresh listings.
+
+    Returns:
+        None: The coroutine runs indefinitely until cancelled.
+    """
+    callbacks = {CANDLES: candle_handler}
     while True:
         try:
-            current = Binance.symbols()
-            current = [s for s in current if symbol_type in s]
+            current = exchange_class.symbols()
+            current = filter_symbols(current, symbol_type, whitelist, blacklist, log_missing=False)
 
             current_set = set(current)
             added = list(current_set.difference(known_symbols))
@@ -88,10 +135,19 @@ async def symbols_watcher(handler: FeedHandler, symbol_type: str, timeframe: str
 
             if added:
                 logger.info(f'Watcher: detected {len(added)} newly listed symbols. Hot-adding shards.')
-                # Add in shards up to 100 symbols per feed
-                for idx, chunk in enumerate(chunks(sorted(added), 100)):
+                # Add shards sized identically to the initial bootstrap.
+                for idx, chunk in enumerate(chunks(sorted(added), shard_size)):
                     logger.info(f'Watcher: add shard with {len(chunk)} symbols')
-                    handler.add_feed(Binance(symbols=chunk, channels=[CANDLES], callbacks=callbacks, candle_interval=timeframe, candle_closed_only=True))
+                    handler.add_feed(
+                        create_exchange(
+                            exchange_name,
+                            symbols=chunk,
+                            channels=[CANDLES],
+                            callbacks=callbacks,
+                            candle_interval=timeframe,
+                            candle_closed_only=True,
+                        )
+                    )
                 known_symbols.update(added)
 
             if removed:
@@ -108,85 +164,249 @@ async def symbols_watcher(handler: FeedHandler, symbol_type: str, timeframe: str
         await asyncio.sleep(interval_sec)
 
 
-async def candle_callback(candle, receipt_timestamp) -> None:
-    """Callback function that stores candle data into ClickHouse.
+def load_config(path: str = CONFIG_PATH) -> dict:
+    """Load runtime configuration from YAML.
 
     Args:
-        candle: The candle data.
-        receipt_timestamp: The receipt timestamp.
+        path (str): Path to the configuration file.
 
+    Returns:
+        dict: Parsed configuration dictionary (empty when file is blank).
     """
-    #logger.info(candle)
+    with open(path, 'r') as ymlfile:
+        return yaml.load(ymlfile, Loader=yaml.SafeLoader) or {}
 
-    exchange = candle.exchange
-    symbol = candle.symbol
-    start = datetime.fromtimestamp(candle.start)
-    stop = datetime.fromtimestamp(candle.stop)
-    interval = candle.interval
-    trades = candle.trades
-    open_price = Decimal(candle.open)
-    close_price = Decimal(candle.close)
-    high_price = Decimal(candle.high)
-    low_price = Decimal(candle.low)
-    volume = Decimal(candle.volume)
-    #closed = (candle.closed)
-    timestamp = datetime.fromtimestamp(candle.timestamp)
-    #receipt_timestamp = receipt_timestamp
-    
-    query = '''
-        INSERT INTO binance_data.candles 
-        (exchange, symbol, start, stop, close_unixtime, interval, trades, open, close, high, low, volume, timestamp, receipt_timestamp)
-        VALUES 
-        (%(exchange)s, %(symbol)s, %(start)s, %(stop)s, %(close_unixtime)s, %(interval)s, %(trades)s, %(open)s, %(close)s, %(high)s, %(low)s, %(volume)s, %(timestamp)s, %(receipt_timestamp)s)
-    '''
 
-    ch = AIOClickHouseClient(host='clickhouse', port=9000,)
-    await ch.execute(query, {'exchange': exchange, 'symbol': symbol, 'start': start, 'stop': stop, 'close_unixtime': candle.stop, 'interval': interval, 'trades': trades, 'open': open_price, 'close': close_price, 'high': high_price, 'low': low_price, 'volume': volume, 'timestamp': timestamp, 'receipt_timestamp': receipt_timestamp})
+def make_candle_callback(host: str, port: int) -> Callable[..., Awaitable[None]]:
+    """Build an async candle handler bound to the given ClickHouse endpoint.
+
+    Args:
+        host (str): ClickHouse host to connect to.
+        port (int): ClickHouse port to connect to.
+
+    Returns:
+        Callable[..., Awaitable[None]]: Coroutine that persists candles.
+    """
+
+    # Reuse a single ClickHouse client per callback to avoid leaking new TCP sessions.
+    client_holder: dict[str, Optional[AIOClickHouseClient]] = {'client': None}
+    lock = asyncio.Lock()
+
+    async def get_client() -> AIOClickHouseClient:
+        client = client_holder['client']
+        if client is None:
+            client = AIOClickHouseClient(host=host, port=port)
+            client_holder['client'] = client
+        return client
+
+    async def reset_client() -> None:
+        client = client_holder['client']
+        if not client:
+            return
+        close = getattr(client, 'close', None)
+        if callable(close):
+            result = close()
+            if asyncio.iscoroutine(result):
+                await result
+        else:
+            disconnect = getattr(client, 'disconnect', None)
+            if callable(disconnect):
+                result = disconnect()
+                if asyncio.iscoroutine(result):
+                    await result
+        client_holder['client'] = None
+
+    async def candle_callback(candle, receipt_timestamp) -> None:
+        """Persist processed candle data into ClickHouse.
+
+        Args:
+            candle: Candle payload provided by cryptofeed.
+            receipt_timestamp: Timestamp recorded by cryptofeed when the candle was received.
+
+        Returns:
+            None: The coroutine completes once the candle is stored.
+        """
+        exchange = candle.exchange
+        symbol = candle.symbol
+        start = datetime.fromtimestamp(candle.start, tz=timezone.utc)
+        stop = datetime.fromtimestamp(candle.stop, tz=timezone.utc)
+        interval = candle.interval
+        trades = int(candle.trades)
+        open_price = float(Decimal(candle.open))
+        close_price = float(Decimal(candle.close))
+        high_price = float(Decimal(candle.high))
+        low_price = float(Decimal(candle.low))
+        volume = float(Decimal(candle.volume))
+        timestamp = datetime.fromtimestamp(candle.timestamp, tz=timezone.utc)
+
+        if isinstance(receipt_timestamp, datetime):
+            receipt_ts = receipt_timestamp.astimezone(timezone.utc) if receipt_timestamp.tzinfo else receipt_timestamp.replace(tzinfo=timezone.utc)
+        else:
+            receipt_ts = datetime.fromtimestamp(receipt_timestamp, tz=timezone.utc)
+
+        async with lock:
+            last_error: Exception | None = None
+            for attempt in range(3):
+                client = await get_client()
+                try:
+                    await client.execute(
+                        INSERT_CANDLES_QUERY,
+                        {
+                            'exchange': exchange,
+                            'symbol': symbol,
+                            'interval': interval,
+                            'start': start,
+                            'stop': stop,
+                            'close_unixtime': int(candle.stop),
+                            'trades': trades,
+                            'open': open_price,
+                            'high': high_price,
+                            'low': low_price,
+                            'close': close_price,
+                            'volume': volume,
+                            'timestamp': timestamp,
+                            'receipt_timestamp': receipt_ts,
+                        },
+                    )
+                    break
+                except Exception as exc:
+                    last_error = exc
+                    logger.warning(f'ClickHouse write failed (attempt {attempt + 1}/3): {exc}')
+                    await reset_client()
+            else:
+                assert last_error is not None
+                raise last_error
+
+    return candle_callback
 
 
 # symbols_callback removed: dynamic symbol management will be handled by a dedicated watcher/manager
 
 
-if __name__ == '__main__':
-    logger.info(f'Delay start by 10sec so that BD are ready')
-    time.sleep(10)
-    logger.info(f'start')
+def main() -> None:
+    """Run the Binance candle collector."""
+    config = load_config(CONFIG_PATH)
+    # Merge host/port overrides before any ClickHouse interaction.
 
-    ####### LOAD CONFIG #########################################################
-    with open("config.yaml", 'r') as ymlfile:
-        config = yaml.load(ymlfile, Loader=yaml.SafeLoader)
+    shard_size = int(config.get('SHARD_SIZE', DEFAULT_SHARD_SIZE))
+    watcher_interval_sec = int(config.get('WATCHER_INTERVAL_SEC', DEFAULT_WATCHER_INTERVAL_SEC))
+    startup_delay_sec = int(config.get('STARTUP_DELAY_SEC', DEFAULT_STARTUP_DELAY_SEC))
 
-    SYMBOLS_TYPE = config['SYMBOLS_TYPE']
-    TIMEFRAME = config['TIMEFRAME']
+    logger.info(f'Delay start by {startup_delay_sec} sec so that DB are ready')
+    time.sleep(startup_delay_sec)
+    logger.info('start')
 
-    # Set up the FeedHandler
+    symbol_type = config['SYMBOLS_TYPE']
+    timeframe = config['TIMEFRAME']
+    symbols_whitelist = config.get('SYMBOLS_WHITELIST') or []
+    symbols_blacklist = config.get('SYMBOLS_BLACKLIST') or []
+
+    clickhouse_host = config.get('CLICKHOUSE_HOST', DEFAULT_CLICKHOUSE_HOST)
+    clickhouse_port = int(config.get('CLICKHOUSE_PORT', DEFAULT_CLICKHOUSE_PORT))
+
+    exchange_name = (
+        config.get('COLLECTOR_EXCHANGE')
+        or config.get('EXCHANGE')
+        or 'binance'
+    )
+    exchange_class = get_exchange_class(exchange_name)
+
+    def format_preview(collection: Sequence[str], limit: int, *, empty_label: str) -> str:
+        """Return a short textual preview for Telegram notifications."""
+        if not collection:
+            return empty_label
+        preview = ', '.join(collection[:limit])
+        extras = len(collection) - limit
+        if extras > 0:
+            preview += f' (+{extras} more)'
+        return preview
+
+    candle_handler = make_candle_callback(clickhouse_host, clickhouse_port)
+    notifier = TelegramNotifier.from_config(config)
+    startup_notified = False
+
+    # Restart the capture loop whenever the handler stops (e.g., network hiccups).
     while True:
-        logger.info(f'Start new loop')
-        create_database_if_not_exists()
-        create_table_if_not_exists()
+        logger.info('Start new loop')
+        ensure_schema(clickhouse_host, clickhouse_port)
+        logger.info('ClickHouse schema ensured')
 
-        symbols = Binance.symbols()
-        symbols = [symbol for symbol in symbols if SYMBOLS_TYPE in symbol]
+        symbols = filter_symbols(
+            exchange_class.symbols(),
+            symbol_type,
+            symbols_whitelist,
+            symbols_blacklist,
+        )
         logger.info(f'Add symbols: {len(symbols)}')
-        
-        callbacks = {CANDLES: candle_callback}
-        #binance = Binance(symbols=symbols, channels=[CANDLES,], callbacks=callbacks)
 
-        f = FeedHandler()
-        loop = asyncio.get_event_loop()
-        #f.add_feed(binance)
+        if notifier and not startup_notified:
+            whitelist_preview = format_preview(symbols_whitelist, 5, empty_label='auto')
+            blacklist_preview = format_preview(symbols_blacklist, 5, empty_label='[]')
+            sample_symbols = format_preview(symbols, 10, empty_label='none')
 
-        # Sharded subscription: batch symbols into groups of up to 100 symbols per feed
-        for idx, chunk in enumerate(chunks(symbols, 100)):
+            message_lines = [
+                'Collector started',
+                '-----------------',
+                f'Timeframe        : {timeframe}',
+                f'Exchange         : {exchange_name}',
+                f'Symbol filter    : {symbol_type}',
+                f'Total symbols    : {len(symbols)}',
+                f'Shard size       : {shard_size}',
+                f'ClickHouse       : {clickhouse_host}:{clickhouse_port}',
+                '',
+                f'Whitelist preview: {whitelist_preview}',
+                f'Blacklist preview: {blacklist_preview}',
+                #f'Symbol sample    : {sample_symbols}',
+            ]
+            notifier.send('\n'.join(message_lines))
+            startup_notified = True
+
+        callbacks = {CANDLES: candle_handler}
+        feed_handler = FeedHandler()
+        # Python 3.12 + uvloop: в главном потоке по умолчанию нет текущего event loop.
+        # Создаём и устанавливаем новый цикл явно.
+        event_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(event_loop)
+
+        for idx, chunk in enumerate(chunks(symbols, shard_size)):
             logger.info(f'ADD shard {idx} feed with {len(chunk)} symbols')
-            f.add_feed(Binance(symbols=chunk, channels=[CANDLES], callbacks=callbacks, candle_interval=TIMEFRAME, candle_closed_only=True))
+            # Keep shard size within Binance limits to avoid subscription drops.
+            feed_handler.add_feed(
+                create_exchange(
+                    exchange_name,
+                    symbols=chunk,
+                    channels=[CANDLES],
+                    callbacks=callbacks,
+                    candle_interval=timeframe,
+                    candle_closed_only=True,
+                )
+            )
 
-        # Start the data collection
-        f.run(start_loop=False)
+        feed_handler.run(start_loop=False)
 
-        # Start watcher task to hot-add new symbols every 60s; removals will be handled via partial shard restart
         known_symbols = set(symbols)
-        loop.create_task(symbols_watcher(f, SYMBOLS_TYPE, TIMEFRAME, known_symbols, interval_sec=60))
+        # Keep subscriptions fresh by tracking newly listed symbols in the background.
+        # Явно используем созданный выше цикл для фоновой задачи
+        event_loop.create_task(
+            symbols_watcher(
+                feed_handler,
+                exchange_name,
+                exchange_class,
+                symbol_type,
+                timeframe,
+                known_symbols,
+                symbols_whitelist,
+                symbols_blacklist,
+                candle_handler,
+                shard_size=shard_size,
+                interval_sec=watcher_interval_sec,
+            )
+        )
 
-        loop.run_forever()
+        event_loop.run_forever()
+        # Brief pause prevents a tight restart loop on repeated failures.
         time.sleep(5)
+
+
+if __name__ == '__main__':
+    main()

--- a/app/data_quality_check.py
+++ b/app/data_quality_check.py
@@ -1,14 +1,16 @@
 import clickhouse_driver
-import requests
 from loguru import logger
 import sys
 import datetime
 import time
 import yaml
 import pandas as pd
-from cryptofeed.exchanges import BinanceFutures
+from data_collector import DEFAULT_CLICKHOUSE_HOST, DEFAULT_CLICKHOUSE_PORT
 from load_history import candle_save
 from progressbar import progressbar
+from telegram_notifier import TelegramNotifier
+
+from exchange_factory import get_exchange_class
 
 
 logger.remove()
@@ -26,25 +28,52 @@ logger.add("./logs/data_quality_check.log", rotation="1 MB", level="DEBUG", comp
 with open("config.yaml", 'r') as ymlfile:
     config = yaml.load(ymlfile, Loader=yaml.SafeLoader)
 
-TELEGRAM_TOKEN = config['TELEGRAM_TOKEN']
-CHAT_ID = config['CHAT_ID']
+CLICKHOUSE_HOST = config.get('CLICKHOUSE_HOST', DEFAULT_CLICKHOUSE_HOST)
+CLICKHOUSE_PORT = int(config.get('CLICKHOUSE_PORT', DEFAULT_CLICKHOUSE_PORT))
+TIMEFRAME = config.get('TIMEFRAME', '1m')
+EXCHANGE_NAME = (
+    config.get('DATA_QUALITY_EXCHANGE')
+    or config.get('HISTORY_EXCHANGE')
+    or config.get('EXCHANGE')
+    or 'binance'
+)
+
+exchange_class = get_exchange_class(EXCHANGE_NAME)
+exchange_instance = exchange_class()
+
+notifier = TelegramNotifier.from_config(config)
+
+# Configurable startup delay for data_quality_check (seconds)
+DEFAULT_STARTUP_DELAY_SEC = 120
+STARTUP_DELAY_SEC = int(config.get('DATA_QUALITY_STARTUP_DELAY_SEC', DEFAULT_STARTUP_DELAY_SEC))
 
 ####### FUNC #################################################################
 
-def bot_send_msg(message: str) -> None:
-    """
-    Sends a message via Telegram API.
+def timeframe_to_pandas_freq(timeframe: str) -> str:
+    """Convert application timeframe (e.g., ``1m``) into a pandas frequency."""
+    timeframe = (timeframe or '').strip().lower()
+    match = None
+    if timeframe:
+        import re
 
-    Args:
-    message: A string message to be sent to the user.
-    """
-    url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/sendMessage?chat_id={CHAT_ID}&text={message}"
-    try:
-        response = requests.get(url)
-        if response.status_code == 200:
-            logger.info("Telegram message sent successfully.")
-    except requests.exceptions.RequestException as e:
-        logger.error(f"Telegram message failed to send. Error: {e}")
+        match = re.match(r'^(\d+)([smhdw])$', timeframe)
+    if not match:
+        raise ValueError(f'Unsupported timeframe value: {timeframe!r}')
+
+    value, unit = match.groups()
+    mapping = {
+        's': 'S',
+        'm': 'min',  # minutes
+        'h': 'H',
+        'd': 'D',
+        'w': 'W',
+    }
+    if unit not in mapping:
+        raise ValueError(f'Unsupported timeframe unit: {unit!r}')
+    return f"{value}{mapping[unit]}"
+
+
+RESAMPLE_FREQUENCY = timeframe_to_pandas_freq(TIMEFRAME)
 
 def data_to_df(data: list) -> pd.DataFrame:
     """
@@ -59,19 +88,19 @@ def data_to_df(data: list) -> pd.DataFrame:
     columns = [
         'exchange',
         'symbol',
+        'interval',
         'start',
         'stop',
         'close_unixtime',
-        'interval',
         'trades',
         'open',
-        'close',
         'high',
         'low',
+        'close',
         'volume',
         'timestamp',
         'receipt_timestamp',
-        ]
+    ]
     df = pd.DataFrame(data, columns=columns)
     df.sort_values(by='stop', ascending=False, inplace=True)
     return(df)
@@ -87,14 +116,25 @@ def check_last_data_recording(ch: clickhouse_driver.Client) -> None:
     result = ch.execute(query)
     if not result:
         logger.error(f'No result from clickhouse!')
+        return
 
     df = data_to_df(result)
     df.drop_duplicates(subset='symbol', inplace=True)
     
-    time_diff = datetime.datetime.now() - df.stop.min()
+    current_time = datetime.datetime.now(datetime.timezone.utc)
+    oldest_stop = df.stop.min()
+    time_diff = current_time - oldest_stop
     if time_diff > datetime.timedelta(minutes=2):
-        message = f"!!! Error !!! The last recording in the ClickHouse database is more than 2 minutes old, now: {datetime.datetime.now()} data: {df.stop.min()}"
-        bot_send_msg(message)
+        message_lines = [
+            'Data freshness alert',
+            '--------------------',
+            f'Current time : {current_time}',
+            f'Last candle  : {oldest_stop}',
+            f'Lag          : {time_diff}',
+        ]
+        message = '\n'.join(message_lines)
+        if notifier:
+            notifier.send(message)
         logger.error(message)
 
 def load_missing_data(missing_dates: list, symbol: str) -> None:
@@ -108,21 +148,59 @@ def load_missing_data(missing_dates: list, symbol: str) -> None:
     start_date = (missing_dates[0] - datetime.timedelta(minutes=5)).to_pydatetime()
     end_date = (missing_dates[-1] + datetime.timedelta(minutes=5)).to_pydatetime()
 
-    message = f'Missing values found! symbol: {symbol}, dates start:{missing_dates[0]}, end:{missing_dates[-1]}'
-    bot_send_msg(message)
+    message_lines = [
+        'Missing candles detected',
+        '------------------------',
+        f'Symbol : {symbol}',
+        f'First  : {missing_dates[0]}',
+        f'Last   : {missing_dates[-1]}',
+        f'Count  : {len(missing_dates)}',
+    ]
+    message = '\n'.join(message_lines)
+    if notifier:
+        notifier.send(message)
     logger.error(message)
 
     logger.info('Start load Missing values')
 
-    for data in BinanceFutures().candles_sync(symbol, start=start_date, end=end_date):
-        for row in data:
-            candle_save(row, datetime.datetime.now())
+    try:
+        with clickhouse_driver.Client(host=CLICKHOUSE_HOST, port=CLICKHOUSE_PORT) as ch:
+            for data in exchange_instance.candles_sync(
+                symbol,
+                start=start_date,
+                end=end_date,
+                interval=TIMEFRAME,
+            ):
+                for row in data:
+                    candle_save(
+                        row,
+                        datetime.datetime.now(datetime.timezone.utc),
+                        CLICKHOUSE_HOST,
+                        CLICKHOUSE_PORT,
+                        client=ch,
+                    )
+    except Exception as exc:
+        logger.error(f'Failed to load missing data for {symbol}: {exc}')
+        if notifier:
+            notifier.send(
+                '\n'.join(
+                    [
+                        'Missing candles reload failed',
+                        '-----------------------------',
+                        f'Symbol : {symbol}',
+                        f'Window : {start_date} -> {end_date}',
+                        f'Error  : {exc}',
+                    ]
+                )
+            )
+        return
             
     message = f'Finish load Missing values in {symbol}'
-    #bot_send_msg(message)
+    # if notifier:
+    #     notifier.send(message)
     logger.info(message)
 
-def find_missing_dates(df: pd.DataFrame, symbol: str) -> list:
+def find_missing_dates(df: pd.DataFrame, symbol: str, resample_freq: str) -> list:
     """
     Finds missing dates for a specific symbol in a DataFrame.
     
@@ -137,17 +215,12 @@ def find_missing_dates(df: pd.DataFrame, symbol: str) -> list:
     data_tmp.sort_values(by='start', ascending=True, inplace=True)
 
     if data_tmp.duplicated(['start',], keep=False).sum() > 0:
-        logger.info(f'duplicates found on {symbol}')
-
-        with clickhouse_driver.Client(host='clickhouse', port=9000) as ch:
-            query = f'OPTIMIZE TABLE binance_data.candles FINAL DEDUPLICATE'
-            _ = ch.execute(query)
-
+        logger.info(f'duplicates found on {symbol}; dropping in-memory copy (table optimize handled separately)')
         data_tmp.drop_duplicates(subset='start', inplace=True)
 
     data_tmp = data_tmp.set_index('start', drop=False)
     # Reindex the data by time
-    data_tmp_rs = data_tmp.resample('1min').asfreq()
+    data_tmp_rs = data_tmp.resample(resample_freq).asfreq()
     # Output the dates that are missing in the data
     missing_dates = list(data_tmp_rs[data_tmp_rs.isna().any(axis=1)].index)
     return missing_dates
@@ -165,7 +238,7 @@ def check_missing_last_data(ch: clickhouse_driver.Client, depth: int = 3000) -> 
     df = data_to_df(result)
 
     for symbol in df.symbol.unique():
-        missing_dates = find_missing_dates(df, symbol)
+        missing_dates = find_missing_dates(df, symbol, RESAMPLE_FREQUENCY)
         if len(missing_dates) > 0:
             logger.info(f'Found missing data for {symbol}! Total: {len(missing_dates)}')
             load_missing_data(missing_dates, symbol)
@@ -174,7 +247,7 @@ def check_missing_full_data() -> None:
     """
     Checks for missing data in the full data set in ClickHouse.
     """
-    with clickhouse_driver.Client(host='clickhouse', port=9000) as ch:
+    with clickhouse_driver.Client(host=CLICKHOUSE_HOST, port=CLICKHOUSE_PORT) as ch:
         query = f'SELECT * FROM binance_data.candles FINAL ORDER BY timestamp DESC LIMIT 4000'
         result = ch.execute(query)
         df = data_to_df(result)
@@ -184,7 +257,7 @@ def check_missing_full_data() -> None:
             result = ch.execute(query, {'symbol': symbol,})
 
             df = data_to_df(result)
-            missing_dates = find_missing_dates(df, symbol)
+            missing_dates = find_missing_dates(df, symbol, RESAMPLE_FREQUENCY)
 
             if len(missing_dates) > 0:
                 load_missing_data(missing_dates, symbol)
@@ -194,15 +267,15 @@ def main():
     The main function that runs the script in a loop.
     """
     while True:
-        with clickhouse_driver.Client(host='clickhouse', port=9000) as ch:
+        with clickhouse_driver.Client(host=CLICKHOUSE_HOST, port=CLICKHOUSE_PORT) as ch:
             check_last_data_recording(ch)
             check_missing_last_data(ch)
         time.sleep(120)
 
 ####### Main #################################################################
 if __name__ == '__main__':
-    logger.info(f'Delay start by 120sec so that BD are ready')
-    time.sleep(120)
+    logger.info(f'Delay start by {STARTUP_DELAY_SEC} sec so that DB are ready')
+    time.sleep(STARTUP_DELAY_SEC)
 
     logger.info(f'Start check all data')
     check_missing_full_data()

--- a/app/exchange_factory.py
+++ b/app/exchange_factory.py
@@ -1,0 +1,38 @@
+"""Utility helpers to instantiate cryptofeed exchanges by config name."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Type
+
+from cryptofeed.exchanges import Binance, BinanceFutures
+
+
+ExchangeClass = Type[Any]
+
+
+_EXCHANGE_REGISTRY: Dict[str, ExchangeClass] = {
+    'binance': Binance,
+    'binance_spot': Binance,
+    'binance_futures': BinanceFutures,
+    'binance-perp': BinanceFutures,
+}
+
+
+def get_exchange_class(name: str) -> ExchangeClass:
+    """Return the cryptofeed exchange class configured by ``name``."""
+
+    if not name:
+        name = 'binance'
+    key = name.strip().lower()
+    try:
+        return _EXCHANGE_REGISTRY[key]
+    except KeyError as exc:
+        supported = ', '.join(sorted(_EXCHANGE_REGISTRY.keys()))
+        raise ValueError(f'Unsupported exchange "{name}". Supported: {supported}') from exc
+
+
+def create_exchange(name: str, **kwargs):
+    """Instantiate the configured exchange class."""
+
+    exchange_cls = get_exchange_class(name)
+    return exchange_cls(**kwargs)

--- a/app/load_history.py
+++ b/app/load_history.py
@@ -1,144 +1,366 @@
-import time
-from loguru import logger
-import sys
+"""Backfill historical Binance candles into ClickHouse."""
+
+import asyncio
 import datetime
-import yaml
-from progressbar import progressbar
+import sys
+import time
 from decimal import Decimal
+from typing import Dict, List, Optional
 
-from cryptofeed.exchanges import Binance
 import clickhouse_driver
+from loguru import logger
+from progressbar import progressbar
 
-####### Logger Configuration #########################################################
-
-# Remove the default sink and add a new sink to stderr with a custom format and log level
-logger.remove()
-logger.add(
-    sys.stderr,
-    colorize=True,
-    format="<green>{time:HH:mm:ss:ms}</green> | <level>{message}</level>",
-    level=10,
+from data_collector import (
+    DEFAULT_CLICKHOUSE_HOST,
+    DEFAULT_CLICKHOUSE_PORT,
+    CONFIG_PATH,
+    filter_symbols,
+    load_config,
 )
+from clickhouse_schema import INSERT_CANDLES_QUERY
+from exchange_factory import get_exchange_class
+from telegram_notifier import TelegramNotifier
 
-# Add a file sink with DEBUG level and compression
-logger.add("./logs/load_history.log", rotation="1 MB", level="DEBUG", compression="zip")
-
-####### Load Config #########################################################
-
-with open("config.yaml", 'r') as ymlfile:
-    config = yaml.load(ymlfile, Loader=yaml.SafeLoader)
-
-START_DATE: str = config['START_DATE']
-LOAD_HISTORY: bool = config['LOAD_HISTORY']
+HISTORY_STARTUP_DELAY_SEC = 200
+DEFAULT_HISTORY_CHUNK_SIZE = 1000
 
 
-####### Functions #########################################################
+def candle_save(
+    candle,
+    receipt_timestamp: datetime.datetime,
+    host: str,
+    port: int,
+    *,
+    client: Optional[clickhouse_driver.Client] = None,
+) -> None:
+    """Insert Binance candle data into ClickHouse.
 
-def candle_save(candle, receipt_timestamp: datetime.datetime) -> None:
-    """Inserts the given candle data into ClickHouse.
-
-    Args:
-        candle: A dictionary containing candle data.
-        receipt_timestamp: A datetime object representing the receipt timestamp.
-
+    When a reusable ClickHouse ``client`` is provided, it is used directly to avoid
+    opening a fresh TCP connection per candle. Otherwise a short-lived client is
+    created for the duration of the insert.
     """
     exchange = candle.exchange
     symbol = candle.symbol
-    start = datetime.datetime.fromtimestamp(candle.start)
-    stop = datetime.datetime.fromtimestamp(candle.stop)
+    start = datetime.datetime.fromtimestamp(candle.start, tz=datetime.timezone.utc)
+    stop = datetime.datetime.fromtimestamp(candle.stop, tz=datetime.timezone.utc)
     interval = candle.interval
-    trades = candle.trades
-    open_price = Decimal(candle.open)
-    close_price = Decimal(candle.close)
-    high_price = Decimal(candle.high)
-    low_price = Decimal(candle.low)
-    volume = Decimal(candle.volume)
-    #closed = (candle.closed)
-    timestamp = datetime.datetime.fromtimestamp(candle.timestamp)
-    
-    query = '''
-        INSERT INTO binance_data.candles 
-        (exchange, symbol, start, stop, close_unixtime, interval, trades, open, close, high, low, volume, timestamp, receipt_timestamp)
-        VALUES 
-        (%(exchange)s, %(symbol)s, %(start)s, %(stop)s, %(close_unixtime)s, %(interval)s, %(trades)s, %(open)s, %(close)s, %(high)s, %(low)s, %(volume)s, %(timestamp)s, %(receipt_timestamp)s)
-    '''
+    trades = int(candle.trades)
+    open_price = float(Decimal(candle.open))
+    close_price = float(Decimal(candle.close))
+    high_price = float(Decimal(candle.high))
+    low_price = float(Decimal(candle.low))
+    volume = float(Decimal(candle.volume))
+    timestamp = datetime.datetime.fromtimestamp(candle.timestamp, tz=datetime.timezone.utc)
 
-    with clickhouse_driver.Client(host='clickhouse', port=9000) as ch:
-        ch.execute(query, {'exchange': exchange, 'symbol': symbol, 'start': start, 'stop': stop, 'close_unixtime': candle.stop, 'interval': interval, 'trades': trades, 'open': open_price, 'close': close_price, 'high': high_price, 'low': low_price, 'volume': volume, 'timestamp': timestamp, 'receipt_timestamp': receipt_timestamp})
+    receipt_ts = (
+        receipt_timestamp.astimezone(datetime.timezone.utc)
+        if receipt_timestamp.tzinfo
+        else receipt_timestamp.replace(tzinfo=datetime.timezone.utc)
+    )
+
+    if client is None:
+        with clickhouse_driver.Client(host=host, port=port) as executor:
+            executor.execute(
+                INSERT_CANDLES_QUERY,
+                {
+                    'exchange': exchange,
+                    'symbol': symbol,
+                    'interval': interval,
+                    'start': start,
+                    'stop': stop,
+                    'close_unixtime': int(candle.stop),
+                    'trades': trades,
+                    'open': open_price,
+                    'high': high_price,
+                    'low': low_price,
+                    'close': close_price,
+                    'volume': volume,
+                    'timestamp': timestamp,
+                    'receipt_timestamp': receipt_ts,
+                },
+            )
+    else:
+        client.execute(
+            INSERT_CANDLES_QUERY,
+            {
+                'exchange': exchange,
+                'symbol': symbol,
+                'interval': interval,
+                'start': start,
+                'stop': stop,
+                'close_unixtime': int(candle.stop),
+                'trades': trades,
+                'open': open_price,
+                'high': high_price,
+                'low': low_price,
+                'close': close_price,
+                'volume': volume,
+                'timestamp': timestamp,
+                'receipt_timestamp': receipt_ts,
+            },
+        )
 
 
-def get_symbols_last_date() -> dict:
-    """Returns a dictionary containing the last date for each symbol in the ClickHouse database.
+def parse_timeframe_delta(timeframe: str) -> datetime.timedelta:
+    """Translate timeframe string (e.g. ``1m``) into a ``timedelta``."""
+    value = timeframe.strip().lower()
+    match = None
+    if value:
+        import re
 
-    Returns:
-        A dictionary containing symbol names as keys and the corresponding last date as values.
+        match = re.match(r'^(\d+)([smhdw])$', value)
+    if not match:
+        raise ValueError(f'Unsupported timeframe value: {timeframe!r}')
 
+    amount, unit = match.groups()
+    amount_int = int(amount)
+    mapping = {
+        's': datetime.timedelta(seconds=amount_int),
+        'm': datetime.timedelta(minutes=amount_int),
+        'h': datetime.timedelta(hours=amount_int),
+        'd': datetime.timedelta(days=amount_int),
+        'w': datetime.timedelta(weeks=amount_int),
+    }
+    if unit not in mapping:
+        raise ValueError(f'Unsupported timeframe unit: {unit!r}')
+    return mapping[unit]
+
+
+def to_utc(dt: datetime.datetime) -> datetime.datetime:
+    """Normalize naive datetimes to UTC."""
+    if dt.tzinfo:
+        return dt.astimezone(datetime.timezone.utc)
+    return dt.replace(tzinfo=datetime.timezone.utc)
+
+def format_ch_time(dt: datetime.datetime) -> str:
     """
-    with clickhouse_driver.Client(host='clickhouse', port=9000) as ch:
-        result = ch.execute('SELECT symbol, MIN(stop) as min_date FROM binance_data.candles FINAL GROUP BY symbol')
-    
-    symbol_last_data_dict = {}
-    for res in result:
-        symbol_last_data_dict[res[0]] = res[1]
-    return(symbol_last_data_dict)
+    ClickHouse/Binance backfill expects 'YYYY-MM-DD HH:MM:SS' (UTC) without 'T' or offset.
+    """
+    dt_utc = to_utc(dt)
+    return dt_utc.strftime('%Y-%m-%d %H:%M:%S')
 
 
-####### Main #########################################################
+def fetch_symbol_earliest_start(
+    host: str,
+    port: int,
+    exchange_id: str,
+    interval: str,
+) -> Dict[str, datetime.datetime]:
+    """Fetch earliest recorded candle start per symbol for the given exchange/interval."""
+
+    query = (
+        'SELECT symbol, MIN(start) '
+        'FROM binance_data.candles FINAL '
+        'WHERE exchange = %(exchange)s AND interval = %(interval)s '
+        'GROUP BY symbol'
+    )
+
+    with clickhouse_driver.Client(host=host, port=port) as ch:
+        rows = ch.execute(query, {'exchange': exchange_id, 'interval': interval})
+
+    return {symbol: to_utc(start) for symbol, start in rows}
+
+
+def main() -> None:
+    """Entry point for historical backfill."""
+    logger.remove()
+    logger.add(
+        sys.stderr,
+        colorize=True,
+        format="<green>{time:HH:mm:ss:ms}</green> | <level>{message}</level>",
+        level=10,
+    )
+    logger.add("./logs/load_history.log", rotation="1 MB", level="DEBUG", compression="zip")
+
+    config = load_config(CONFIG_PATH)
+    if not config.get('LOAD_HISTORY'):
+        logger.info('No history load')
+        return
+
+    start_date_raw = config['START_DATE']
+    start_date_dt = to_utc(datetime.datetime.fromisoformat(start_date_raw))
+    start_date_iso = start_date_dt.isoformat()
+    symbol_type = config['SYMBOLS_TYPE']
+    timeframe = config['TIMEFRAME']
+    whitelist = config.get('SYMBOLS_WHITELIST') or []
+    blacklist = config.get('SYMBOLS_BLACKLIST') or []
+    clickhouse_host = config.get('CLICKHOUSE_HOST', DEFAULT_CLICKHOUSE_HOST)
+    clickhouse_port = int(config.get('CLICKHOUSE_PORT', DEFAULT_CLICKHOUSE_PORT))
+    timeframe_delta = parse_timeframe_delta(timeframe)
+    history_chunk_size = int(config.get('HISTORY_CHUNK_SIZE', DEFAULT_HISTORY_CHUNK_SIZE))
+    if history_chunk_size <= 0:
+        raise ValueError('HISTORY_CHUNK_SIZE must be a positive integer')
+    if history_chunk_size > 1500:
+        logger.warning('HISTORY_CHUNK_SIZE too large (%s); clamping to 1500 to satisfy exchange limits', history_chunk_size)
+        history_chunk_size = 1500
+    chunk_span = timeframe_delta * history_chunk_size
+
+    exchange_name = (
+        config.get('HISTORY_EXCHANGE')
+        or config.get('EXCHANGE')
+        or 'binance'
+    )
+    exchange_class = get_exchange_class(exchange_name)
+
+    logger.info(f'Delay start by {HISTORY_STARTUP_DELAY_SEC} sec so that all are ready')
+    time.sleep(HISTORY_STARTUP_DELAY_SEC)
+    logger.info('START HISTORY LOAD')
+
+    notifier = TelegramNotifier.from_config(config)
+
+    exchange = exchange_class()
+    exchange_id = getattr(exchange, 'id', exchange_name.upper())
+
+    target_symbols = filter_symbols(exchange_class.symbols(), symbol_type, whitelist, blacklist)
+    if not target_symbols:
+        logger.warning('No symbols matched whitelist/blacklist filters; skipping history load')
+        return
+    successful_symbols: List[str] = []
+    failed_details: List[str] = []
+
+    safe_now = datetime.datetime.now(datetime.timezone.utc) - timeframe_delta
+    if safe_now <= start_date_dt:
+        logger.info(
+            'Backfill skipped: start date {} is not earlier than safe horizon {}',
+            start_date_iso,
+            safe_now,
+        )
+        return
+
+    earliest_starts = fetch_symbol_earliest_start(
+        clickhouse_host,
+        clickhouse_port,
+        exchange_id,
+        timeframe,
+    )
+
+    try:
+        for symbol in progressbar(target_symbols, redirect_stdout=True):
+            logger.info(
+                'Load history for {} from {} down to {} (chunk={} candles)',
+                symbol,
+                safe_now,
+                start_date_iso,
+                history_chunk_size,
+            )
+
+            earliest_existing = earliest_starts.get(symbol)
+            if earliest_existing:
+                end_cursor = min(safe_now, earliest_existing - timeframe_delta)
+            else:
+                end_cursor = safe_now
+
+            if end_cursor <= start_date_dt:
+                logger.info(
+                    'Skip %s: existing history (%s) covers requested range starting at %s',
+                    symbol,
+                    earliest_existing,
+                    start_date_iso,
+                )
+                continue
+
+            chunk_counter = 0
+            if notifier:
+                message_lines = [
+                    'History load started',
+                    '--------------------',
+                f'Symbol          : {symbol}',
+                f'Timeframe       : {timeframe}',
+                f'Requested range : {start_date_iso} -> {end_cursor.isoformat()}',
+                f'Chunks          : size {history_chunk_size} candles',
+                f'Exchange        : {exchange_name}',
+            ]
+            notifier.send('\n'.join(message_lines))
+
+            try:
+                with clickhouse_driver.Client(host=clickhouse_host, port=clickhouse_port) as ch:
+                    while end_cursor > start_date_dt:
+                        chunk_start = max(start_date_dt, end_cursor - chunk_span)
+                        params = dict(
+                            start=format_ch_time(chunk_start),
+                            end=format_ch_time(end_cursor),
+                            interval=timeframe,
+                        )
+                        logger.debug(
+                            'Symbol {} chunk #{}: {} -> {}',
+                            symbol,
+                            chunk_counter + 1,
+                            params['start'],
+                            params['end'],
+                        )
+                        for data in exchange.candles_sync(symbol, **params):
+                            for row in data:
+                                candle_save(
+                                    row,
+                                    datetime.datetime.now(datetime.timezone.utc),
+                                    clickhouse_host,
+                                    clickhouse_port,
+                                    client=ch,
+                                )
+                        chunk_counter += 1
+                        if chunk_start == start_date_dt:
+                            break
+                        end_cursor = chunk_start
+
+                logger.info(f'Finish load history: {symbol}')
+                successful_symbols.append(symbol)
+                if notifier:
+                    message_lines = [
+                        'History load finished',
+                        '---------------------',
+                        f'Symbol    : {symbol}',
+                        f'Chunks    : {chunk_counter}',
+                        f'Range     : {start_date_iso} -> {safe_now.isoformat()}',
+                        'Status    : completed successfully.',
+                    ]
+                    notifier.send('\n'.join(message_lines))
+            except Exception as exc:
+                logger.error(f'Error: {exc}')
+                logger.error(
+                    'Error processing {} chunking from {} to {}',
+                    symbol,
+                    start_date_iso,
+                    safe_now.isoformat(),
+                )
+                failed_details.append(f'{symbol}: {exc}')
+                if notifier:
+                    message_lines = [
+                        'History load failed',
+                        '-------------------',
+                        f'Symbol    : {symbol}',
+                        f'Range     : {start_date_iso} -> {safe_now.isoformat()}',
+                        f'Error     : {exc}',
+                    ]
+                    notifier.send('\n'.join(message_lines))
+    finally:
+        closer = getattr(exchange, 'close', None)
+        if callable(closer):
+            result = closer()
+            if asyncio.iscoroutine(result):
+                asyncio.run(result)
+
+    logger.info('ALL history is loaded!')
+    if notifier:
+        summary_lines = [
+            'History load summary',
+            '--------------------',
+            f'Total symbols : {len(target_symbols)}',
+            f'Successful    : {len(successful_symbols)}',
+            f'Failed        : {len(failed_details)}',
+            f'Chunk size     : {history_chunk_size} candles',
+            f'Exchange       : {exchange_name}',
+        ]
+        if failed_details:
+            summary_lines.append('')
+            summary_lines.append('Failures:')
+            for detail in failed_details[:5]:
+                summary_lines.append(f'- {detail}')
+            extras = len(failed_details) - 5
+            if extras > 0:
+                summary_lines.append(f'  (+{extras} more)')
+        notifier.send('\n'.join(summary_lines))
+
 
 if __name__ == '__main__':
-    if LOAD_HISTORY:
-        logger.info(f'Delay start by 2000sec so that all are ready')
-        time.sleep(2000)
-        logger.info(f'START HISTORY LOAD')
-
-        ####### LOAD CONFIG #########################################################
-        with open("config.yaml", 'r') as ymlfile:
-            config = yaml.load(ymlfile, Loader=yaml.SafeLoader)
-
-        SYMBOLS_TYPE = config['SYMBOLS_TYPE']
-        TIMEFRAME = config['TIMEFRAME']
-
-        # start load top10 symbols
-        # SYMBOLS_TYPE = '-USDT-PERP'
-        SYMBOLS = [
-            "BTC",
-            "ETH",
-            "BNB",
-            "ADA",
-            "XRP",
-            "MATIC",
-            "LTC",
-            "TRX",
-            "DOT",
-            "AVAX",
-            "LINK",
-            "ATOM",
-            "UNI",
-        ]
-        for symbol in SYMBOLS:
-            logger.info(f'Load top10 SYMBOLS history: {symbol} from {START_DATE}')
-            # Loop with unknown finite number of iterations
-            for data in Binance().candles_sync(symbol+SYMBOLS_TYPE, start=START_DATE, interval=TIMEFRAME):
-                for row in data:
-                    candle_save(row, datetime.datetime.now())
-            logger.info(f'Finish load top10 history: {symbol}')
-
-        # Get the last stop date for each symbol
-        symbol_last_data_dict = get_symbols_last_date()
-
-        # Loop through each symbol and load its history
-        for symbol, last_date in progressbar(symbol_last_data_dict.items(), redirect_stdout=True):
-            logger.info(f'Load history: {symbol} from {START_DATE} to {last_date}')
-            # Loop with unknown finite number of iterations
-            try:
-                for data in Binance().candles_sync(symbol, start=START_DATE, end=last_date, interval=TIMEFRAME):
-                    for row in data:
-                        candle_save(row, datetime.datetime.now())
-                logger.info(f'Finish load history: {symbol}')
-            except Exception as e:
-                logger.error(f'Error: {e}')
-                logger.error(f'Error: {symbol} from {START_DATE} to {last_date}')
-        logger.info(f'ALL history is loaded!')
-
-    else:
-        logger.info(f'No history load')
+    main()

--- a/app/telegram_notifier.py
+++ b/app/telegram_notifier.py
@@ -1,0 +1,52 @@
+"""Utilities for sending Telegram notifications."""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional, Any, Union
+
+import requests
+from loguru import logger
+
+
+class TelegramNotifier:
+    """Thin wrapper around Telegram Bot API for simple text notifications."""
+
+    def __init__(self, token: Union[str, int], chat_id: Union[str, int], *, timeout: float = 10.0) -> None:
+        # Accept ints from YAML (e.g., CHAT_ID: 123456) and coerce to str
+        self._token = str(token).strip()
+        self._chat_id = str(chat_id).strip()
+        self._timeout = timeout
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any], *, timeout: float = 10.0) -> Optional["TelegramNotifier"]:
+        """Build a notifier when bot credentials are present in the config."""
+        token = (config or {}).get("TELEGRAM_TOKEN")
+        chat_id = (config or {}).get("CHAT_ID")
+        if not token or not chat_id:
+            logger.debug("Telegram notifier not configured (missing token or chat id).")
+            return None
+        return cls(token, chat_id, timeout=timeout)
+
+    def send(self, message: str) -> bool:
+        """Send a text message to the configured Telegram chat."""
+        if not message:
+            logger.debug("Telegram notifier skipped empty message.")
+            return False
+
+        url = f"https://api.telegram.org/bot{self._token}/sendMessage"
+        payload = {"chat_id": self._chat_id, "text": message}
+
+        try:
+            response = requests.post(url, data=payload, timeout=self._timeout)
+            if response.status_code == 200:
+                logger.debug("Telegram message sent successfully.")
+                return True
+
+            logger.error(
+                f"Telegram message failed with status {response.status_code}: {response.text}"
+            )
+        except requests.exceptions.RequestException as exc:
+            logger.error(f"Telegram message failed due to network error: {exc}")
+
+        return False
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   data_collector:
     build: .
@@ -34,7 +33,7 @@ services:
     image: yandex/clickhouse-server
     restart: always
     ports:
-      - "127.0.0.1:8124:8123"
-      - "127.0.0.1:9001:9000"
+      - "127.0.0.1:18124:8123"
+      - "127.0.0.1:19001:9000"
     volumes:
       - ./data:/var/lib/clickhouse

--- a/notebooks/ohlcv_views.ipynb
+++ b/notebooks/ohlcv_views.ipynb
@@ -1,0 +1,2180 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Просмотр OHLCV по материализованным витринам\n",
+    "\n",
+    "Минимальный набор утилит для запроса свечей из ClickHouse и визуализации данных. Перед запуском убедитесь, что ClickHouse доступен.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "54c8e2c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Найти корень проекта с пакетом `app`\n",
+    "for candidate in (Path.cwd(), *Path.cwd().parents):\n",
+    "    if (candidate / 'app').is_dir():\n",
+    "        if str(candidate) not in sys.path:\n",
+    "            sys.path.append(str(candidate))\n",
+    "        break\n",
+    "else:\n",
+    "    raise RuntimeError('Не удалось найти каталог с пакетом app')\n",
+    "\n",
+    "import pandas as pd\n",
+    "import plotly.graph_objects as go\n",
+    "import clickhouse_driver\n",
+    "\n",
+    "from app.clickhouse_schema import (\n",
+    "    DATABASE_NAME,\n",
+    "    CANDLES_TABLE,\n",
+    "    CANDLES_TABLE_FULL,\n",
+    "    BASE_INTERVAL,\n",
+    "    ROLLUP_SPECS,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7a4f1ec5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DEFAULT_CLICKHOUSE_HOST = os.getenv('CLICKHOUSE_HOST', 'localhost')\n",
+    "DEFAULT_CLICKHOUSE_PORT = int(os.getenv('CLICKHOUSE_PORT', '19001'))\n",
+    "DEFAULT_CLICKHOUSE_USER = os.getenv('CLICKHOUSE_USER', 'default')\n",
+    "DEFAULT_CLICKHOUSE_PASSWORD = os.getenv('CLICKHOUSE_PASSWORD', '')\n",
+    "DEFAULT_CLICKHOUSE_DB = os.getenv('CLICKHOUSE_DATABASE', DATABASE_NAME)\n",
+    "\n",
+    "TABLES: dict[str, dict[str, object]] = {\n",
+    "    CANDLES_TABLE: {\n",
+    "        'full_name': CANDLES_TABLE_FULL,\n",
+    "        'label': BASE_INTERVAL,\n",
+    "        'time_column': 'start',\n",
+    "        'is_rollup': False,\n",
+    "        'needs_interval': True,\n",
+    "    }\n",
+    "}\n",
+    "for spec in ROLLUP_SPECS:\n",
+    "    TABLES[spec.table_name] = {\n",
+    "        'full_name': spec.table_full,\n",
+    "        'label': spec.label,\n",
+    "        'time_column': 'candle_start',\n",
+    "        'is_rollup': True,\n",
+    "        'needs_interval': False,\n",
+    "    }\n",
+    "\n",
+    "def build_client_kwargs(*, host: str, port: int, user: str, password: str, database: str, secure: bool = False) -> dict[str, object]:\n",
+    "    client_kwargs: dict[str, object] = {\n",
+    "        'host': host or 'localhost',\n",
+    "        'port': int(port),\n",
+    "        'database': database or DATABASE_NAME,\n",
+    "        'user': user or 'default',\n",
+    "    }\n",
+    "    if password:\n",
+    "        client_kwargs['password'] = password\n",
+    "    if secure:\n",
+    "        client_kwargs['secure'] = True\n",
+    "        client_kwargs.setdefault('verify', False)\n",
+    "    return client_kwargs\n",
+    "\n",
+    "def fetch_recent_ohlcv(*, table_name: str, exchange: str, symbol: str, interval: str | None, limit: int, client_kwargs: dict[str, object]) -> pd.DataFrame:\n",
+    "    table = TABLES[table_name]\n",
+    "    params: dict[str, object] = {\n",
+    "        'exchange': exchange,\n",
+    "        'symbol': symbol,\n",
+    "        'limit': max(1, int(limit)),\n",
+    "    }\n",
+    "    time_column = table['time_column']\n",
+    "    if table['is_rollup']:\n",
+    "        query = f\"\"\"\n",
+    "            SELECT\n",
+    "                {time_column} AS ts,\n",
+    "                argMinMerge(open)   AS open,\n",
+    "                maxMerge(high)     AS high,\n",
+    "                minMerge(low)      AS low,\n",
+    "                argMaxMerge(close) AS close,\n",
+    "                sumMerge(volume)   AS volume,\n",
+    "                sumMerge(trades)   AS trades\n",
+    "            FROM {table['full_name']}\n",
+    "            WHERE exchange = %(exchange)s\n",
+    "              AND symbol = %(symbol)s\n",
+    "            GROUP BY exchange, symbol, {time_column}\n",
+    "            ORDER BY ts DESC\n",
+    "            LIMIT %(limit)s\n",
+    "        \"\"\"\n",
+    "    else:\n",
+    "        if table['needs_interval'] and not interval:\n",
+    "            raise ValueError('Для этой таблицы необходимо указать таймфрейм.')\n",
+    "        params['interval'] = interval\n",
+    "        query = f\"\"\"\n",
+    "            SELECT\n",
+    "                {time_column} AS ts,\n",
+    "                open,\n",
+    "                high,\n",
+    "                low,\n",
+    "                close,\n",
+    "                volume,\n",
+    "                trades\n",
+    "            FROM {table['full_name']}\n",
+    "            WHERE exchange = %(exchange)s\n",
+    "              AND symbol = %(symbol)s\n",
+    "              AND interval = %(interval)s\n",
+    "            ORDER BY ts DESC\n",
+    "            LIMIT %(limit)s\n",
+    "        \"\"\"\n",
+    "    with clickhouse_driver.Client(**client_kwargs) as client:\n",
+    "        rows = client.execute(query, params)\n",
+    "    df = pd.DataFrame(rows, columns=['ts', 'open', 'high', 'low', 'close', 'volume', 'trades'])\n",
+    "    if df.empty:\n",
+    "        return df\n",
+    "    df['ts'] = pd.to_datetime(df['ts'], utc=True)\n",
+    "    return df.sort_values('ts').reset_index(drop=True)\n",
+    "\n",
+    "def plot_candles(df: pd.DataFrame, title: str) -> go.Figure:\n",
+    "    fig = go.Figure(go.Candlestick(\n",
+    "        x=df['ts'],\n",
+    "        open=df['open'],\n",
+    "        high=df['high'],\n",
+    "        low=df['low'],\n",
+    "        close=df['close'],\n",
+    "        name='OHLC',\n",
+    "        increasing_line_color='#00C087',\n",
+    "        decreasing_line_color='#FF4B4B',\n",
+    "        increasing_fillcolor='#00C087',\n",
+    "        decreasing_fillcolor='#FF4B4B',\n",
+    "    ))\n",
+    "    fig.update_layout(\n",
+    "        title=title,\n",
+    "        xaxis_title='Время (UTC)',\n",
+    "        yaxis_title='Цена',\n",
+    "        xaxis_rangeslider_visible=False,\n",
+    "        template='plotly_dark',\n",
+    "        paper_bgcolor='#181A20',\n",
+    "        plot_bgcolor='#181A20',\n",
+    "        hovermode='x unified',\n",
+    "    )\n",
+    "    fig.update_xaxes(gridcolor='#23272F', showline=True, linecolor='#23272F')\n",
+    "    fig.update_yaxes(gridcolor='#23272F', showline=True, linecolor='#23272F')\n",
+    "    return fig\n",
+    "\n",
+    "def show_recent_chart(*, table_name: str, exchange: str, symbol: str, interval: str | None, limit: int, client_kwargs: dict[str, object]) -> None:\n",
+    "    df = fetch_recent_ohlcv(\n",
+    "        table_name=table_name,\n",
+    "        exchange=exchange,\n",
+    "        symbol=symbol,\n",
+    "        interval=interval,\n",
+    "        limit=limit,\n",
+    "        client_kwargs=client_kwargs,\n",
+    "    )\n",
+    "    if df.empty:\n",
+    "        print('Нет данных для выбранных параметров')\n",
+    "        return\n",
+    "    table_label = TABLES[table_name]['label']\n",
+    "    plot_candles(df, title=f'{symbol} ({table_label})').show()\n",
+    "\n",
+    "CLIENT_KWARGS = build_client_kwargs(\n",
+    "    host=DEFAULT_CLICKHOUSE_HOST,\n",
+    "    port=DEFAULT_CLICKHOUSE_PORT,\n",
+    "    user=DEFAULT_CLICKHOUSE_USER,\n",
+    "    password=DEFAULT_CLICKHOUSE_PASSWORD,\n",
+    "    database=DEFAULT_CLICKHOUSE_DB,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "62878caa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "close": {
+          "bdata": "6Nms+lxt5T/o2az6XG3lP3E9CtejcOU/yjLEsS5u5T+P5PIf0m/lPwaBlUOLbOU/YHZPHhZq5T9+HThnRGnlP0LPZtXnauU/nMQgsHJo5T8kKH6MuWvlP0LPZtXnauU/Qs9m1edq5T9xPQrXo3DlP3E9CtejcOU/2/l+arx05T9kXdxGA3jlP4EExY8xd+U/n6ut2F925T+fq63YX3blPxdIUPwYc+U/U5YhjnVx5T+si9toAG/lP8oyxLEubuU/BoGVQ4ts5T8xCKwcWmTlP34dOGdEaeU/1xLyQc9m5T8TYcPTK2XlP0+vlGWIY+U/1xLyQc9m5T9gdk8eFmrlP2B2Tx4WauU/PujZrPpc5T+2hHzQs1nlP0vIBz2bVeU/WKg1zTtO5T8Mk6mCUUnlP5T2Bl+YTOU/0ETY8PRK5T8dWmQ730/lP5T2Bl+YTOU/YqHWNO845T/0/dR46SblP9ZW7C+7J+U/2T15WKg15T9R2ht8YTLlP+oENBE2POU/6gQ0ETY85T8IrBxaZDvlP2Kh1jTvOOU/yXa+nxov5T+NKO0NvjDlP8l2vp8aL+U/QBNhw9Mr5T/Jdr6fGi/lPyJseHqlLOU/1lbsL7sn5T9N845TdCTlP7ivA+eMKOU/iUFg5dAi5T8wTKYKRiXlP03zjlN0JOU/QBNhw9Mr5T98YTJVMCrlP40o7Q2+MOU/MzMzMzMz5T/nHafoSC7lPwXFjzF3LeU/mggbnl4p5T8ibHh6pSzlP7ivA+eMKOU/Imx4eqUs5T/WVuwvuyflP2uad5yiI+U/W9O84xQd5T8B3gIJih/lP5oIG55eKeU/fGEyVTAq5T/nHafoSC7lP1HaG3xhMuU/XrpJDAIr5T98YTJVMCrlP/T91HjpJuU/MEymCkYl5T+n6Egu/yHlP8WPMXctIeU/9P3UeOkm5T+aCBueXinlPyJseHqlLOU/jSjtDb4w5T+NKO0NvjDlP/fkYaHWNOU/UdobfGEy5T+8lpAPejblP/fkYaHWNOU/RPrt68A55T+ASL99HTjlP40o7Q2+MOU/MzMzMzMz5T8=",
+          "dtype": "f8"
+         },
+         "decreasing": {
+          "fillcolor": "#FF4B4B",
+          "line": {
+           "color": "#FF4B4B"
+          }
+         },
+         "high": {
+          "bdata": "6Nms+lxt5T+P5PIf0m/lP9v5fmq8dOU/vVKWIY515T9TliGOdXHlP4/k8h/Sb+U/6Nms+lxt5T8kKH6MuWvlPyQofoy5a+U/Qs9m1edq5T8kKH6MuWvlP8oyxLEubuU/6Nms+lxt5T9TliGOdXHlPxdIUPwYc+U/gQTFjzF35T8oDwu1pnnlP2Rd3EYDeOU/7MA5I0p75T+BBMWPMXflP5+rrdhfduU/F0hQ/Bhz5T9TliGOdXHlP3E9CtejcOU/rIvbaABv5T/o2az6XG3lPyQofoy5a+U/YHZPHhZq5T9gdk8eFmrlP5zEILByaOU/1xLyQc9m5T8kKH6MuWvlP+jZrPpcbeU/Qs9m1edq5T+ppE5AE2HlP7aEfNCzWeU/LSEf9GxW5T87AU2EDU/lP5T2Bl+YTOU/lPYGX5hM5T8dWmQ730/lP8NkqmBUUuU/sp3vp8ZL5T9iodY07zjlP57vp8ZLN+U/6gQ0ETY85T+8lpAPejblP8xdS8gHPeU/rrZif9k95T+utmJ/2T3lP662Yn/ZPeU/CKwcWmQ75T9vgQTFjzHlP6vP1VbsL+U/yXa+nxov5T/Jdr6fGi/lPxWMSuoENOU/QBNhw9Mr5T/WVuwvuyflP7ivA+eMKOU/uK8D54wo5T8wTKYKRiXlP5oIG55eKeU/5x2n6Egu5T8FxY8xdy3lP40o7Q2+MOU/vJaQD3o25T+ASL99HTjlP+cdp+hILuU/jSjtDb4w5T/nHafoSC7lP+cdp+hILuU/BcWPMXct5T+NKO0NvjDlP7ivA+eMKOU/EqW9wRcm5T8B3gIJih/lP5oIG55eKeU/QBNhw9Mr5T/nHafoSC7lPzMzMzMzM+U/MzMzMzMz5T8ibHh6pSzlP3xhMlUwKuU/9P3UeOkm5T9eukkMAivlP4lBYOXQIuU/9P3UeOkm5T98YTJVMCrlPwXFjzF3LeU/jSjtDb4w5T9R2ht8YTLlP/fkYaHWNOU/9+RhodY05T/qBDQRNjzlP57vp8ZLN+U/RPrt68A55T8mUwWjkjrlP57vp8ZLN+U/MzMzMzMz5T8=",
+          "dtype": "f8"
+         },
+         "increasing": {
+          "fillcolor": "#00C087",
+          "line": {
+           "color": "#00C087"
+          }
+         },
+         "low": {
+          "bdata": "MQisHFpk5T8GgZVDi2zlP+jZrPpcbeU/6Nms+lxt5T8kKH6MuWvlP0LPZtXnauU/fh04Z0Rp5T+cxCCwcmjlP21Wfa62YuU/9bnaiv1l5T+6awn5oGflP34dOGdEaeU/1xLyQc9m5T8kKH6MuWvlP8oyxLEubuU/U5YhjnVx5T8XSFD8GHPlP/mgZ7Pqc+U/vVKWIY515T817zhFR3LlPzXvOEVHcuU/6Nms+lxt5T8kKH6MuWvlPyQofoy5a+U/JCh+jLlr5T+L/WX35GHlP0+vlGWIY+U/ApoIG55e5T9Pr5RliGPlP4v9ZffkYeU/x0s3iUFg5T/XEvJBz2blP5zEILByaOU/XI/C9Shc5T/y0k1iEFjlP8NkqmBUUuU/WKg1zTtO5T+h1jTvOEXlP2aIY13cRuU/gy9MpgpG5T9miGNd3EblP9BE2PD0SuU/PSzUmuYd5T+GWtO84xTlP03zjlN0JOU/9P3UeOkm5T9AE2HD0yvlP40o7Q2+MOU/YqHWNO845T9E+u3rwDnlP4BIv30dOOU/BcWPMXct5T9AE2HD0yvlP5oIG55eKeU/XrpJDAIr5T9eukkMAivlPyJseHqlLOU/p+hILv8h5T/jNhrAWyDlP+M2GsBbIOU/xY8xdy0h5T/jNhrAWyDlP4lBYOXQIuU/TfOOU3Qk5T98YTJVMCrlP03zjlN0JOU/yXa+nxov5T8FxY8xdy3lP3xhMlUwKuU/1lbsL7sn5T+aCBueXinlPzBMpgpGJeU/uK8D54wo5T8Spb3BFyblP6foSC7/IeU/liGOdXEb5T+0yHa+nxrlPwHeAgmKH+U/1lbsL7sn5T98YTJVMCrlPwXFjzF3LeU/uK8D54wo5T/0/dR46SblP6foSC7/IeU/TfOOU3Qk5T/jNhrAWyDlP3h6pSxDHOU/xY8xdy0h5T+JQWDl0CLlP9ZW7C+7J+U/Imx4eqUs5T8FxY8xdy3lP40o7Q2+MOU/b4EExY8x5T8zMzMzMzPlPzMzMzMzM+U/9+RhodY05T8zMzMzMzPlP8l2vp8aL+U/jSjtDb4w5T8=",
+          "dtype": "f8"
+         },
+         "name": "OHLC",
+         "open": {
+          "bdata": "9bnaiv1l5T/o2az6XG3lP+jZrPpcbeU/U5YhjnVx5T/KMsSxLm7lP6yL22gAb+U/BoGVQ4ts5T9Cz2bV52rlP34dOGdEaeU/Qs9m1edq5T+6awn5oGflPyQofoy5a+U/YHZPHhZq5T8kKH6MuWvlP3E9CtejcOU/U5YhjnVx5T/b+X5qvHTlP2Rd3EYDeOU/ZF3cRgN45T+BBMWPMXflP5+rrdhfduU/F0hQ/Bhz5T9TliGOdXHlP6yL22gAb+U/rIvbaABv5T8GgZVDi2zlPzEIrBxaZOU/YHZPHhZq5T+6awn5oGflP/W52or9ZeU/MQisHFpk5T+6awn5oGflP2B2Tx4WauU/Qs9m1edq5T8gQfFjzF3lP7aEfNCzWeU/LSEf9GxW5T87AU2EDU/lPwyTqYJRSeU/lPYGX5hM5T/QRNjw9ErlPx1aZDvfT+U/sp3vp8ZL5T9iodY07zjlP/T91HjpJuU/9P3UeOkm5T/ZPXlYqDXlP2+BBMWPMeU/6gQ0ETY85T8IrBxaZDvlP+oENBE2POU/gEi/fR045T/Jdr6fGi/lP6vP1VbsL+U/5x2n6Egu5T9AE2HD0yvlP8l2vp8aL+U/QBNhw9Mr5T/WVuwvuyflPzBMpgpGJeU/uK8D54wo5T9rmnecoiPlPzBMpgpGJeU/TfOOU3Qk5T9AE2HD0yvlP5oIG55eKeU/jSjtDb4w5T9R2ht8YTLlPwXFjzF3LeU/BcWPMXct5T98YTJVMCrlP0ATYcPTK+U/mggbnl4p5T8ibHh6pSzlP9ZW7C+7J+U/a5p3nKIj5T89LNSa5h3lPwHeAgmKH+U/mggbnl4p5T98YTJVMCrlP+cdp+hILuU/UdobfGEy5T9AE2HD0yvlP5oIG55eKeU/9P3UeOkm5T8Spb3BFyblP8WPMXctIeU/xY8xdy0h5T/0/dR46SblP5oIG55eKeU/BcWPMXct5T9vgQTFjzHlP40o7Q2+MOU/9+RhodY05T8zMzMzMzPlP9k9eVioNeU/9+RhodY05T9iodY07zjlP57vp8ZLN+U/jSjtDb4w5T8=",
+          "dtype": "f8"
+         },
+         "type": "candlestick",
+         "x": [
+          "2025-10-21T19:34:00",
+          "2025-10-21T19:35:00",
+          "2025-10-21T19:36:00",
+          "2025-10-21T19:37:00",
+          "2025-10-21T19:38:00",
+          "2025-10-21T19:39:00",
+          "2025-10-21T19:40:00",
+          "2025-10-21T19:41:00",
+          "2025-10-21T19:42:00",
+          "2025-10-21T19:43:00",
+          "2025-10-21T19:44:00",
+          "2025-10-21T19:45:00",
+          "2025-10-21T19:46:00",
+          "2025-10-21T19:47:00",
+          "2025-10-21T19:48:00",
+          "2025-10-21T19:49:00",
+          "2025-10-21T19:50:00",
+          "2025-10-21T19:51:00",
+          "2025-10-21T19:52:00",
+          "2025-10-21T19:53:00",
+          "2025-10-21T19:54:00",
+          "2025-10-21T19:55:00",
+          "2025-10-21T19:56:00",
+          "2025-10-21T19:57:00",
+          "2025-10-21T19:58:00",
+          "2025-10-21T19:59:00",
+          "2025-10-21T20:00:00",
+          "2025-10-21T20:01:00",
+          "2025-10-21T20:02:00",
+          "2025-10-21T20:03:00",
+          "2025-10-21T20:04:00",
+          "2025-10-21T20:05:00",
+          "2025-10-21T20:06:00",
+          "2025-10-21T20:07:00",
+          "2025-10-21T20:08:00",
+          "2025-10-21T20:09:00",
+          "2025-10-21T20:10:00",
+          "2025-10-21T20:11:00",
+          "2025-10-21T20:12:00",
+          "2025-10-21T20:13:00",
+          "2025-10-21T20:14:00",
+          "2025-10-21T20:15:00",
+          "2025-10-21T20:16:00",
+          "2025-10-21T20:17:00",
+          "2025-10-21T20:18:00",
+          "2025-10-21T20:19:00",
+          "2025-10-21T20:20:00",
+          "2025-10-21T20:21:00",
+          "2025-10-21T20:22:00",
+          "2025-10-21T20:23:00",
+          "2025-10-21T20:24:00",
+          "2025-10-21T20:25:00",
+          "2025-10-21T20:26:00",
+          "2025-10-21T20:27:00",
+          "2025-10-21T20:28:00",
+          "2025-10-21T20:29:00",
+          "2025-10-21T20:30:00",
+          "2025-10-21T20:31:00",
+          "2025-10-21T20:32:00",
+          "2025-10-21T20:33:00",
+          "2025-10-21T20:34:00",
+          "2025-10-21T20:35:00",
+          "2025-10-21T20:36:00",
+          "2025-10-21T20:37:00",
+          "2025-10-21T20:38:00",
+          "2025-10-21T20:39:00",
+          "2025-10-21T20:40:00",
+          "2025-10-21T20:41:00",
+          "2025-10-21T20:42:00",
+          "2025-10-21T20:43:00",
+          "2025-10-21T20:44:00",
+          "2025-10-21T20:45:00",
+          "2025-10-21T20:46:00",
+          "2025-10-21T20:47:00",
+          "2025-10-21T20:48:00",
+          "2025-10-21T20:49:00",
+          "2025-10-21T20:50:00",
+          "2025-10-21T20:51:00",
+          "2025-10-21T20:52:00",
+          "2025-10-21T20:53:00",
+          "2025-10-21T20:54:00",
+          "2025-10-21T20:55:00",
+          "2025-10-21T20:56:00",
+          "2025-10-21T20:57:00",
+          "2025-10-21T20:58:00",
+          "2025-10-21T20:59:00",
+          "2025-10-21T21:00:00",
+          "2025-10-21T21:01:00",
+          "2025-10-21T21:02:00",
+          "2025-10-21T21:03:00",
+          "2025-10-21T21:04:00",
+          "2025-10-21T21:05:00",
+          "2025-10-21T21:06:00",
+          "2025-10-21T21:07:00",
+          "2025-10-21T21:08:00",
+          "2025-10-21T21:09:00",
+          "2025-10-21T21:10:00",
+          "2025-10-21T21:11:00",
+          "2025-10-21T21:12:00",
+          "2025-10-21T21:13:00"
+         ]
+        }
+       ],
+       "layout": {
+        "hovermode": "x unified",
+        "paper_bgcolor": "#181A20",
+        "plot_bgcolor": "#181A20",
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#f2f5fa"
+            },
+            "error_y": {
+             "color": "#f2f5fa"
+            },
+            "marker": {
+             "line": {
+              "color": "rgb(17,17,17)",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "rgb(17,17,17)",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#A2B1C6",
+             "gridcolor": "#506784",
+             "linecolor": "#506784",
+             "minorgridcolor": "#506784",
+             "startlinecolor": "#A2B1C6"
+            },
+            "baxis": {
+             "endlinecolor": "#A2B1C6",
+             "gridcolor": "#506784",
+             "linecolor": "#506784",
+             "minorgridcolor": "#506784",
+             "startlinecolor": "#A2B1C6"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "marker": {
+             "line": {
+              "color": "#283442"
+             }
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "line": {
+              "color": "#283442"
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#506784"
+             },
+             "line": {
+              "color": "rgb(17,17,17)"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#2a3f5f"
+             },
+             "line": {
+              "color": "rgb(17,17,17)"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#f2f5fa",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#f2f5fa"
+          },
+          "geo": {
+           "bgcolor": "rgb(17,17,17)",
+           "lakecolor": "rgb(17,17,17)",
+           "landcolor": "rgb(17,17,17)",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#506784"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "dark"
+          },
+          "paper_bgcolor": "rgb(17,17,17)",
+          "plot_bgcolor": "rgb(17,17,17)",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           },
+           "bgcolor": "rgb(17,17,17)",
+           "radialaxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "rgb(17,17,17)",
+            "gridcolor": "#506784",
+            "gridwidth": 2,
+            "linecolor": "#506784",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#C8D4E3"
+           },
+           "yaxis": {
+            "backgroundcolor": "rgb(17,17,17)",
+            "gridcolor": "#506784",
+            "gridwidth": 2,
+            "linecolor": "#506784",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#C8D4E3"
+           },
+           "zaxis": {
+            "backgroundcolor": "rgb(17,17,17)",
+            "gridcolor": "#506784",
+            "gridwidth": 2,
+            "linecolor": "#506784",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#C8D4E3"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#f2f5fa"
+           }
+          },
+          "sliderdefaults": {
+           "bgcolor": "#C8D4E3",
+           "bordercolor": "rgb(17,17,17)",
+           "borderwidth": 1,
+           "tickwidth": 0
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           },
+           "bgcolor": "rgb(17,17,17)",
+           "caxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "updatemenudefaults": {
+           "bgcolor": "#506784",
+           "borderwidth": 0
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#283442",
+           "linecolor": "#506784",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#283442",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#283442",
+           "linecolor": "#506784",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#283442",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "ADA-USDT-PERP (1m)"
+        },
+        "xaxis": {
+         "gridcolor": "#23272F",
+         "linecolor": "#23272F",
+         "rangeslider": {
+          "visible": false
+         },
+         "showline": true,
+         "title": {
+          "text": "Время (UTC)"
+         }
+        },
+        "yaxis": {
+         "gridcolor": "#23272F",
+         "linecolor": "#23272F",
+         "showline": true,
+         "title": {
+          "text": "Цена"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Пример: последние 200 свечей из базовой таблицы\n",
+    "show_recent_chart(\n",
+    "    table_name=CANDLES_TABLE,\n",
+    "    exchange='BINANCE_FUTURES',\n",
+    "    symbol='ADA-USDT-PERP',\n",
+    "    interval=BASE_INTERVAL,\n",
+    "    limit=100,\n",
+    "    client_kwargs=CLIENT_KWARGS,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "fc043fa7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "close": {
+          "bdata": "XynLEMe65D+Nl24Sg8DkPwFNhA1Pr+Q/I9v5fmq85D9BguLHmLvkP8nlP6TfvuQ/FvvL7snD5D+1N/jCZKrkPwkbnl4py+Q/uB6F61G45D/gvg6cM6LkP/CFyVTBqOQ/097gC5Op5D8FNBE2PL3kP0w3iUFg5eQ/kzoBTYQN5T9eukkMAivlP4lBYOXQIuU/Qj7o2az65D/Sb18HzhnlPx+F61G4HuU/W9O84xQd5T8Zc9cS8kHlP3ZPHhZqTeU/xSCwcmiR5T90JJf/kH7lP6pgVFInoOU/JuSDns2q5T9y+Q/pt6/lP0Jg5dAi2+U/qDXNO07R5T/D9Shcj8LlP6Fns+pzteU/m1Wfq63Y5T8+eVioNc3lPxkEVg4tsuU/h6dXyjLE5T9cIEHxY8zlPzqSy39Iv+U/m1Wfq63Y5T8GEhQ/xtzlPz55WKg1zeU/E/JBz2bV5T96xyk6ksvlP/5D+u3rwOU/CyQofoy55T9LWYY41sXlP1FrmnecouU/U5YhjnVx5T9Wfa62Yn/lP3gLJCh+jOU/K/aX3ZOH5T/UK2UZ4ljlP4v9ZffkYeU/CmgibHh65T8XSFD8GHPlP5+rrdhfduU/hetRuB6F5T851sVtNIDlP1OWIY51ceU/YHZPHhZq5T+wcmiR7XzlP8oyxLEubuU/OwFNhA1P5T+yne+nxkvlPzEIrBxaZOU/8tJNYhBY5T9pb/CFyVTlP6W9wRcmU+U//7J78rBQ5T9Pr5RliGPlP5jdk4eFWuU/E2HD0ytl5T+6awn5oGflPwaBlUOLbOU/cT0K16Nw5T+fq63YX3blP9QrZRniWOU/fh04Z0Rp5T/o2az6XG3lPwaBlUOLbOU/JCh+jLlr5T/b+X5qvHTlPxdIUPwYc+U/MQisHFpk5T/XEvJBz2blP0vIBz2bVeU/HVpkO99P5T/ZPXlYqDXlP2Kh1jTvOOU/yXa+nxov5T+JQWDl0CLlP40o7Q2+MOU/Imx4eqUs5T9b07zjFB3lP1HaG3xhMuU/p+hILv8h5T+NKO0NvjDlP/fkYaHWNOU/zF1LyAc95T8=",
+          "dtype": "f8"
+         },
+         "decreasing": {
+          "fillcolor": "#FF4B4B",
+          "line": {
+           "color": "#FF4B4B"
+          }
+         },
+         "high": {
+          "bdata": "CRueXinL5D+8BRIUP8bkP0Rpb/CFyeQ/yeU/pN++5D9SSZ2AJsLkP2IQWDm0yOQ/2qz6XG3F5D/arPpcbcXkP/s6cM6I0uQ/3pOHhVrT5D/WxW00gLfkP05iEFg5tOQ/eekmMQis5D+Nl24Sg8DkP6kT0ETY8OQ/V+wvuycP5T/Jdr6fGi/lPxlz1xLyQeU/iUFg5dAi5T/FjzF3LSHlP5oIG55eKeU/mggbnl4p5T8Zc9cS8kHlPwKaCBueXuU/mpmZmZmZ5T9/2T15WKjlP4PAyqFFtuU/WDm0yHa+5T9lGeJYF7flP7AD54wo7eU/jnVxGw3g5T8noImw4enlP5huEoPAyuU/fa62Yn/Z5T+OdXEbDeDlP23n+6nx0uU/h6dXyjLE5T8xmSoYldTlPyDSb18HzuU/m1Wfq63Y5T+sHFpkO9/lP6wcWmQ73+U/UiegibDh5T+sHFpkO9/lP4qO5PIf0uU/pU5AE2HD5T/xY8xdS8jlPz55WKg1zeU/rkfhehSu5T+0WfW52orlPxE2PL1SluU/p3nHKTqS5T9aZDvfT43lP21Wfa62YuU/dCSX/5B+5T/9h/Tb14HlPwpoImx4euU/tFn1udqK5T/SAN4CCYrlPznWxW00gOU/Rrbz/dR45T9Wfa62Yn/lP3Qkl/+QfuU/yjLEsS5u5T8tIR/0bFblP/W52or9ZeU/Qs9m1edq5T+Y3ZOHhVrlPy0hH/RsVuU/EHo2qz5X5T/1udqK/WXlP9cS8kHPZuU/umsJ+aBn5T9gdk8eFmrlP6yL22gAb+U/Ne84RUdy5T9kXdxGA3jlP2Rd3EYDeOU/YHZPHhZq5T/o2az6XG3lP71SliGOdeU/6Nms+lxt5T+BBMWPMXflP+zAOSNKe+U/F0hQ/Bhz5T8kKH6MuWvlP+jZrPpcbeU/LSEf9GxW5T/DZKpgVFLlP662Yn/ZPeU/CKwcWmQ75T8VjErqBDTlP40o7Q2+MOU/gEi/fR045T+NKO0NvjDlPzMzMzMzM+U/MzMzMzMz5T+NKO0NvjDlP+oENBE2POU/zF1LyAc95T8=",
+          "dtype": "f8"
+         },
+         "increasing": {
+          "fillcolor": "#00C087",
+          "line": {
+           "color": "#00C087"
+          }
+         },
+         "low": {
+          "bdata": "1sVtNIC35D/WxW00gLfkP6CJsOHpleQ/whcmUwWj5D9sCfmgZ7PkP2wJ+aBns+Q/mnecoiO55D8s1JrmHafkP+C+DpwzouQ/097gC5Op5D9kO99PjZfkPxsN4C2QoOQ/ZDvfT42X5D/whclUwajkP0GC4seYu+Q/TDeJQWDl5D8ydy0hH/TkP8WPMXctIeU/YOXQItv55D9+jLlrCfnkPxueXinLEOU/SgwCK4cW5T+TOgFNhA3lP3Noke18P+U/WKg1zTtO5T/KMsSxLm7lP1Z9rrZif+U/qmBUUieg5T+qYFRSJ6DlP1RSJ6CJsOU/aQBvgQTF5T/+Q/rt68DlP1FrmnecouU/g8DKoUW25T+YbhKDwMrlP65H4XoUruU/GQRWDi2y5T86kst/SL/lP5Cg+DHmruU/duCcEaW95T8CK4cW2c7lP/5D+u3rwOU/XCBB8WPM5T8PC7WmecflPzqSy39Iv+U/zO7Jw0Kt5T+DwMqhRbblPwRWDi2yneU/ApoIG55e5T9tVn2utmLlPygPC7WmeeU/kst/SL995T83GsBbIEHlP6HWNO84ReU/ejarPldb5T/XEvJBz2blP9cS8kHPZuU/2/l+arx05T8XSFD8GHPlP3E9CtejcOU/MQisHFpk5T+cxCCwcmjlP0+vlGWIY+U/KjqSy39I5T9I4XoUrkflP0jhehSuR+U/S8gHPZtV5T//snvysFDlP1XBqKROQOU/7uvAOSNK5T87AU2EDU/lPxB6Nqs+V+U/mN2Th4Va5T8Cmggbnl7lP/W52or9ZeU/E2HD0ytl5T/o2az6XG3lP9QrZRniWOU/8tJNYhBY5T/l8h/Sb1/lP0LPZtXnauU/bVZ9rrZi5T/XEvJBz2blPzXvOEVHcuU/i/1l9+Rh5T8Cmggbnl7lP8NkqmBUUuU/odY07zhF5T+GWtO84xTlP0ATYcPTK+U/mggbnl4p5T/jNhrAWyDlP+M2GsBbIOU/1lbsL7sn5T+WIY51cRvlP7TIdr6fGuU/4zYawFsg5T94eqUsQxzlPwXFjzF3LeU/yXa+nxov5T8=",
+          "dtype": "f8"
+         },
+         "name": "OHLC",
+         "open": {
+          "bdata": "YhBYObTI5D990LNZ9bnkP42XbhKDwOQ/AU2EDU+v5D8j2/l+arzkP18pyxDHuuQ/yeU/pN++5D8W+8vuycPkP7U3+MJkquQ/J8KGp1fK5D/WxW00gLfkP8IXJlMFo+Q/8IXJVMGo5D/T3uALk6nkP+eMKO0NvuQ/TDeJQWDl5D+x4emVsgzlP3xhMlUwKuU/iUFg5dAi5T9g5dAi2/nkP9JvXwfOGeU/H4XrUbge5T9b07zjFB3lPxlz1xLyQeU/WKg1zTtO5T+neccpOpLlP1Z9rrZif+U/qmBUUieg5T8m5IOezarlP1RSJ6CJsOU/JLn8h/Tb5T+oNc07TtHlP8P1KFyPwuU/g8DKoUW25T+bVZ+rrdjlPyDSb18HzuU/GQRWDi2y5T+Hp1fKMsTlP1wgQfFjzOU/OpLLf0i/5T+bVZ+rrdjlPwYSFD/G3OU/PnlYqDXN5T/1SlmGONblP1wgQfFjzOU/HOviNhrA5T/ufD81XrrlPy2yne+nxuU/jLlrCfmg5T9xPQrXo3DlP1Z9rrZif+U/WmQ730+N5T9JnYAmwoblP9QrZRniWOU/i/1l9+Rh5T/swDkjSnvlPxdIUPwYc+U/n6ut2F925T+jkjoBTYTlP1Z9rrZif+U/U5YhjnVx5T9+HThnRGnlP84ZUdobfOU/yjLEsS5u5T9YqDXNO07lP7Kd76fGS+U/MQisHFpk5T/y0k1iEFjlP2lv8IXJVOU/hxbZzvdT5T8dWmQ730/lPzEIrBxaZOU/mN2Th4Va5T8xCKwcWmTlP9cS8kHPZuU/BoGVQ4ts5T9xPQrXo3DlP5+rrdhfduU/1CtlGeJY5T+cxCCwcmjlP+jZrPpcbeU/BoGVQ4ts5T8kKH6MuWvlP9v5fmq8dOU/F0hQ/Bhz5T8xCKwcWmTlP7prCfmgZ+U/LSEf9GxW5T8dWmQ730/lP9k9eVioNeU/gEi/fR045T/Jdr6fGi/lP2uad5yiI+U/jSjtDb4w5T9AE2HD0yvlPz0s1JrmHeU/UdobfGEy5T/FjzF3LSHlP2+BBMWPMeU/9+RhodY05T8=",
+          "dtype": "f8"
+         },
+         "type": "candlestick",
+         "x": [
+          "2025-10-21T12:55:00",
+          "2025-10-21T13:00:00",
+          "2025-10-21T13:05:00",
+          "2025-10-21T13:10:00",
+          "2025-10-21T13:15:00",
+          "2025-10-21T13:20:00",
+          "2025-10-21T13:25:00",
+          "2025-10-21T13:30:00",
+          "2025-10-21T13:35:00",
+          "2025-10-21T13:40:00",
+          "2025-10-21T13:45:00",
+          "2025-10-21T13:50:00",
+          "2025-10-21T13:55:00",
+          "2025-10-21T14:00:00",
+          "2025-10-21T14:05:00",
+          "2025-10-21T14:10:00",
+          "2025-10-21T14:15:00",
+          "2025-10-21T14:20:00",
+          "2025-10-21T14:25:00",
+          "2025-10-21T14:30:00",
+          "2025-10-21T14:35:00",
+          "2025-10-21T14:40:00",
+          "2025-10-21T14:45:00",
+          "2025-10-21T14:50:00",
+          "2025-10-21T14:55:00",
+          "2025-10-21T15:00:00",
+          "2025-10-21T15:05:00",
+          "2025-10-21T15:10:00",
+          "2025-10-21T15:15:00",
+          "2025-10-21T15:20:00",
+          "2025-10-21T15:25:00",
+          "2025-10-21T15:30:00",
+          "2025-10-21T15:35:00",
+          "2025-10-21T15:40:00",
+          "2025-10-21T15:45:00",
+          "2025-10-21T15:50:00",
+          "2025-10-21T15:55:00",
+          "2025-10-21T16:00:00",
+          "2025-10-21T16:05:00",
+          "2025-10-21T16:10:00",
+          "2025-10-21T16:15:00",
+          "2025-10-21T16:20:00",
+          "2025-10-21T16:25:00",
+          "2025-10-21T16:30:00",
+          "2025-10-21T16:35:00",
+          "2025-10-21T16:40:00",
+          "2025-10-21T16:45:00",
+          "2025-10-21T16:50:00",
+          "2025-10-21T16:55:00",
+          "2025-10-21T17:00:00",
+          "2025-10-21T17:05:00",
+          "2025-10-21T17:10:00",
+          "2025-10-21T17:15:00",
+          "2025-10-21T17:20:00",
+          "2025-10-21T17:25:00",
+          "2025-10-21T17:30:00",
+          "2025-10-21T17:35:00",
+          "2025-10-21T17:40:00",
+          "2025-10-21T17:45:00",
+          "2025-10-21T17:50:00",
+          "2025-10-21T17:55:00",
+          "2025-10-21T18:00:00",
+          "2025-10-21T18:05:00",
+          "2025-10-21T18:10:00",
+          "2025-10-21T18:15:00",
+          "2025-10-21T18:20:00",
+          "2025-10-21T18:25:00",
+          "2025-10-21T18:30:00",
+          "2025-10-21T18:35:00",
+          "2025-10-21T18:40:00",
+          "2025-10-21T18:45:00",
+          "2025-10-21T18:50:00",
+          "2025-10-21T18:55:00",
+          "2025-10-21T19:00:00",
+          "2025-10-21T19:05:00",
+          "2025-10-21T19:10:00",
+          "2025-10-21T19:15:00",
+          "2025-10-21T19:20:00",
+          "2025-10-21T19:25:00",
+          "2025-10-21T19:30:00",
+          "2025-10-21T19:35:00",
+          "2025-10-21T19:40:00",
+          "2025-10-21T19:45:00",
+          "2025-10-21T19:50:00",
+          "2025-10-21T19:55:00",
+          "2025-10-21T20:00:00",
+          "2025-10-21T20:05:00",
+          "2025-10-21T20:10:00",
+          "2025-10-21T20:15:00",
+          "2025-10-21T20:20:00",
+          "2025-10-21T20:25:00",
+          "2025-10-21T20:30:00",
+          "2025-10-21T20:35:00",
+          "2025-10-21T20:40:00",
+          "2025-10-21T20:45:00",
+          "2025-10-21T20:50:00",
+          "2025-10-21T20:55:00",
+          "2025-10-21T21:00:00",
+          "2025-10-21T21:05:00",
+          "2025-10-21T21:10:00"
+         ]
+        }
+       ],
+       "layout": {
+        "hovermode": "x unified",
+        "paper_bgcolor": "#181A20",
+        "plot_bgcolor": "#181A20",
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#f2f5fa"
+            },
+            "error_y": {
+             "color": "#f2f5fa"
+            },
+            "marker": {
+             "line": {
+              "color": "rgb(17,17,17)",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "rgb(17,17,17)",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#A2B1C6",
+             "gridcolor": "#506784",
+             "linecolor": "#506784",
+             "minorgridcolor": "#506784",
+             "startlinecolor": "#A2B1C6"
+            },
+            "baxis": {
+             "endlinecolor": "#A2B1C6",
+             "gridcolor": "#506784",
+             "linecolor": "#506784",
+             "minorgridcolor": "#506784",
+             "startlinecolor": "#A2B1C6"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "marker": {
+             "line": {
+              "color": "#283442"
+             }
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "line": {
+              "color": "#283442"
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#506784"
+             },
+             "line": {
+              "color": "rgb(17,17,17)"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#2a3f5f"
+             },
+             "line": {
+              "color": "rgb(17,17,17)"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#f2f5fa",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#f2f5fa"
+          },
+          "geo": {
+           "bgcolor": "rgb(17,17,17)",
+           "lakecolor": "rgb(17,17,17)",
+           "landcolor": "rgb(17,17,17)",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#506784"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "dark"
+          },
+          "paper_bgcolor": "rgb(17,17,17)",
+          "plot_bgcolor": "rgb(17,17,17)",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           },
+           "bgcolor": "rgb(17,17,17)",
+           "radialaxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "rgb(17,17,17)",
+            "gridcolor": "#506784",
+            "gridwidth": 2,
+            "linecolor": "#506784",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#C8D4E3"
+           },
+           "yaxis": {
+            "backgroundcolor": "rgb(17,17,17)",
+            "gridcolor": "#506784",
+            "gridwidth": 2,
+            "linecolor": "#506784",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#C8D4E3"
+           },
+           "zaxis": {
+            "backgroundcolor": "rgb(17,17,17)",
+            "gridcolor": "#506784",
+            "gridwidth": 2,
+            "linecolor": "#506784",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#C8D4E3"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#f2f5fa"
+           }
+          },
+          "sliderdefaults": {
+           "bgcolor": "#C8D4E3",
+           "bordercolor": "rgb(17,17,17)",
+           "borderwidth": 1,
+           "tickwidth": 0
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           },
+           "bgcolor": "rgb(17,17,17)",
+           "caxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "updatemenudefaults": {
+           "bgcolor": "#506784",
+           "borderwidth": 0
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#283442",
+           "linecolor": "#506784",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#283442",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#283442",
+           "linecolor": "#506784",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#283442",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "ADA-USDT-PERP (5m)"
+        },
+        "xaxis": {
+         "gridcolor": "#23272F",
+         "linecolor": "#23272F",
+         "rangeslider": {
+          "visible": false
+         },
+         "showline": true,
+         "title": {
+          "text": "Время (UTC)"
+         }
+        },
+        "yaxis": {
+         "gridcolor": "#23272F",
+         "linecolor": "#23272F",
+         "showline": true,
+         "title": {
+          "text": "Цена"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Пример: последние 100 свечей из материализованной витрины\n",
+    "show_recent_chart(\n",
+    "    table_name='candles_5m',\n",
+    "    exchange='BINANCE_FUTURES',\n",
+    "    symbol='ADA-USDT-PERP',\n",
+    "    interval=None,\n",
+    "    limit=100,\n",
+    "    client_kwargs=CLIENT_KWARGS,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de837b9b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "wenv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ clickhouse-driver
 aioch
 pandas
 progressbar2
+jupyter
+plotly
+ipywidgets


### PR DESCRIPTION
app/data_collector.py: switched to configurable exchanges via get_exchange_class, so shard subscriptions and the watcher run against whichever exchange is set in config.yaml; also added a reusable AIOClickHouseClient with retry logic on write failures.
app/load_history.py: backfill now fetches the earliest stored candle per symbol and only loads missing intervals up to that point, clamps chunk size to 1,500 candles, reuses a single exchange instance, and closes it cleanly even for coroutine-based clients.
app/data_quality_check.py: uses a single exchange instance per process, passes interval=TIMEFRAME when refilling gaps, trims duplicates in memory, and wraps refill calls in try/except with Telegram notifications on failure.
app/config.yaml / app/config_sample.yaml: added EXCHANGE, HISTORY_CHUNK_SIZE, and related knobs to support the new configuration flow.
app/exchange_factory.py: new helper mapping config exchange names to cryptofeed classes.
README.md: refreshed project description, updated Docker Compose guidance, and added a notebook example for data exploration.